### PR TITLE
rename honcho-status skill to just status

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ export HONCHO_WORKSPACE="my-projects"
 
 ## Verifying It Works
 
-After installation, start Claude Code. Just ask Claude if Honcho context is available, or run `/honcho:honcho-status`.
+After installation, start Claude Code. Just ask Claude if Honcho context is available, or run `/honcho:status`.
 
 ---
 
@@ -107,7 +107,7 @@ After installation, start Claude Code. Just ask Claude if Honcho context is avai
 
 | Command | Description |
 |---------|-------------|
-| `/honcho-status` | Show current memory status and configuration |
+| `/honcho:status` | Show current memory status and configuration |
 
 ---
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -17,7 +17,7 @@ Display the current Honcho memory system status, including configuration, sessio
 
 ## Usage
 
-Run `/honcho-status` to see the current state of the Honcho memory system.
+Run `/honcho:status` to see the current state of the Honcho memory system.
 
 ## Implementation
 

--- a/src/skills/status-runner.ts
+++ b/src/skills/status-runner.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 /**
- * Runner script for the honcho-status skill.
+ * Runner script for the status skill.
  * Shows current Honcho memory status and configuration.
  */
 import {
@@ -22,7 +22,7 @@ function status(): void {
   const config = loadConfig();
   if (!config) {
     console.log(s.warn("Not configured"));
-    console.log(s.dim("Run: /honcho-setup or set HONCHO_API_KEY environment variable"));
+    console.log(s.dim("Set HONCHO_API_KEY environment variable"));
     return;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command references from /honcho-status to /honcho:status across documentation and guides.
  * Simplified configuration guidance message displayed when the status command is not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->