### PR TITLE
refactor: remove legacy SDK format support, add visual logging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.1.3"
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },
@@ -21,7 +21,7 @@
       "name": "honcho-dev",
       "source": "./plugins/honcho-dev",
       "description": "Skills for building AI applications with the Honcho SDK",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "keywords": ["sdk", "development", "migration"],
       "strict": false
     }

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The honcho plugin provides these tools via MCP:
 | `HONCHO_ENDPOINT`      | No       | `production`  | `production`, `local`, or a custom URL                            |
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
+| `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
 
 ### Example Configuration
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,43 @@ Claude will interview you about your personal preferences in order to kickstart 
 of you. What it learns will be saved in Honcho and remembered forever. The interview is specific
 to the peer name you chose in your environment: it will carry across different projects!
 
+### Step 6: (Recommended) Configure Your CLAUDE.md
+
+Tell Claude how to use its memory by adding directives to your **personal** `~/.claude/CLAUDE.md`
+(not a project-level `CLAUDE.md`). We use the personal file because Honcho is about *you* — your
+preferences and memory follow you across every project, not just one repo. A project-level
+`CLAUDE.md` would only apply when working in that specific directory.
+
+Paste this into Claude Code:
+
+> Read your `~/.claude/CLAUDE.md` (create it if it doesn't exist). Add the following directives, keeping any existing content:
+>
+> ```
+> # Honcho Memory
+>
+> You have persistent memory via Honcho. Context about me, my preferences,
+> and our past work is loaded automatically at the start of every session.
+>
+> ## How to use it:
+> - Trust the Honcho context injected at session start. It contains what you
+>   know about me — act on it. Do not ignore it or ask me things you already know.
+> - Use `create_conclusion` to save new insights as you learn them: my preferences,
+>   decisions, patterns I like, things I've asked you not to do. Be liberal.
+> - Use `chat` or `search` mid-conversation when you need context beyond what
+>   was loaded at startup.
+> - I should never have to repeat myself. If I've told you something before,
+>   you should already know it.
+>
+> ## Honcho Integration for Projects
+> - When working on a Python or TypeScript project that involves AI agents or
+>   LLM chat but lacks persistent memory, use the `/honcho-integration` skill
+>   to add Honcho. Don't wait to be asked — suggest it early.
+> ```
+>
+> Save the file.
+
+This ensures Claude actively uses Honcho's memory — not just passively receiving context at startup, but saving new insights and querying for deeper context throughout your conversations.
+
 ## What You Get
 
 - **Persistent Memory** — Claude remembers your preferences, projects, and context across sessions

--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ Paste this into Claude Code:
 > ## How to use it:
 > - Trust the Honcho context injected at session start. It contains what you
 >   know about me — act on it. Do not ignore it or ask me things you already know.
-> - Use `create_conclusion` to save new insights as you learn them: my preferences,
->   decisions, patterns I like, things I've asked you not to do. Be liberal.
 > - Use `chat` or `search` mid-conversation when you need context beyond what
 >   was loaded at startup.
+> - Use `create_conclusion` to save new insights as you learn them: my preferences,
+>   decisions, patterns I like, things I've asked you not to do.
 > - I should never have to repeat myself. If I've told you something before,
 >   you should already know it.
 >

--- a/plugins/honcho/bun.lock
+++ b/plugins/honcho/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "claude-honcho",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.0.0",
+        "@honcho-ai/sdk": "~2.0.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
       },
       "devDependencies": {

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -15,7 +15,7 @@
   "author": "Plastic Labs",
   "license": "MIT",
   "dependencies": {
-    "@honcho-ai/sdk": "~2.0.0",
+    "@honcho-ai/sdk": "^2.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [
@@ -15,7 +15,7 @@
   "author": "Plastic Labs",
   "license": "MIT",
   "dependencies": {
-    "@honcho-ai/sdk": "^2.0.0",
+    "@honcho-ai/sdk": "~2.0.0",
     "@modelcontextprotocol/sdk": "^1.0.0"
   },
   "devDependencies": {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,6 +1,10 @@
 import { homedir } from "os";
-import { join } from "path";
+import { join, basename } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+
+function sanitizeForSessionName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
+}
 
 export interface MessageUploadConfig {
   maxUserTokens?: number; // Truncate user messages to this many tokens (null = no limit)
@@ -163,6 +167,21 @@ export function getSessionForPath(cwd: string): string | null {
   const config = loadConfig();
   if (!config?.sessions) return null;
   return config.sessions[cwd] || null;
+}
+
+/**
+ * Default session name: peerName_repoName (e.g. user-repo-name).
+ * If a session is configured for this path, that name is returned instead.
+ */
+export function getSessionName(cwd: string): string {
+  const configuredSession = getSessionForPath(cwd);
+  if (configuredSession) {
+    return configuredSession;
+  }
+  const config = loadConfig();
+  const peerPart = config?.peerName ? sanitizeForSessionName(config.peerName) : "user";
+  const repoPart = sanitizeForSessionName(basename(cwd));
+  return `${peerPart}-${repoPart}`;
 }
 
 export function setSessionForPath(cwd: string, sessionName: string): void {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -175,7 +175,7 @@ export function getSessionForPath(cwd: string): string | null {
 }
 
 /**
- * Default session name: peerName_repoName (e.g. user-repo-name).
+ * Default session name: peerName-repoName (e.g. user-repo-name).
  * If a session is configured for this path, that name is returned instead.
  */
 export function getSessionName(cwd: string): string {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -47,6 +47,7 @@ export interface HonchoCLAUDEConfig {
   endpoint?: HonchoEndpointConfig; // SaaS vs local instance config
   localContext?: LocalContextConfig; // Local claude-context.md settings
   enabled?: boolean; // Temporarily disable plugin (default: true)
+  logging?: boolean; // Enable file logging to ~/.honcho/ (default: true)
 }
 
 const CONFIG_DIR = join(homedir(), ".honcho");
@@ -109,6 +110,7 @@ export function loadConfigFromEnv(): HonchoCLAUDEConfig | null {
     claudePeer,
     saveMessages: process.env.HONCHO_SAVE_MESSAGES !== "false",
     enabled: process.env.HONCHO_ENABLED !== "false",
+    logging: process.env.HONCHO_LOGGING !== "false",
   };
 
   // Handle endpoint configuration
@@ -142,6 +144,9 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
   }
   if (process.env.HONCHO_ENABLED === "false") {
     config.enabled = false;
+  }
+  if (process.env.HONCHO_LOGGING === "false") {
+    config.logging = false;
   }
 
   return config;
@@ -232,6 +237,12 @@ export function getLocalContextConfig(): LocalContextConfig {
   return {
     maxEntries: config?.localContext?.maxEntries ?? 50, // Default 50 entries
   };
+}
+
+// File logging enable/disable
+export function isLoggingEnabled(): boolean {
+  const config = loadConfig();
+  return config?.logging !== false; // default: true
 }
 
 // Plugin enable/disable

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -3,6 +3,7 @@ import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled 
 import { basename } from "path";
 import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
+import { visCapture } from "../visual.js";
 
 
 interface HookInput {
@@ -227,6 +228,7 @@ export async function handlePostToolUse(): Promise<void> {
 
   const summary = formatToolSummary(toolName, toolInput, toolResponse);
   logHook("post-tool-use", summary, { tool: toolName });
+  visCapture(summary);
 
   // INSTANT: Update local claude context file (~2ms)
   appendClaudeWork(summary);

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -1,6 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
-import { basename } from "path";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visCapture } from "../visual.js";
@@ -11,14 +10,6 @@ interface HookInput {
   tool_input?: Record<string, any>;
   tool_response?: Record<string, any>;
   cwd?: string;
-}
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
 function shouldLogTool(toolName: string, toolInput: Record<string, any>): boolean {

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -31,7 +31,7 @@ function formatMemoryCard(
   // Header - identity anchor
   parts.push(`## HONCHO MEMORY ANCHOR (Pre-Compaction Injection)
 This context is being injected because the conversation is about to be summarized.
-These facts MUST be preserved in the summary.
+These conclusions MUST be preserved in the summary.
 
 ### Session Identity
 - User: ${config.peerName}
@@ -46,10 +46,10 @@ These facts MUST be preserved in the summary.
 ${userPeerCard.join("\n")}`);
   }
 
-  // Key user facts
+  // Key user conclusions
   const userRep = userContext?.representation;
   if (typeof userRep === "string" && userRep.trim()) {
-    parts.push(`### Key Facts About ${config.peerName} (PRESERVE)\n${userRep}`);
+    parts.push(`### Key Conclusions About ${config.peerName} (PRESERVE)\n${userRep}`);
   }
 
   // Claude's self-context - what was I working on
@@ -78,7 +78,7 @@ ${claudeDialectic}`);
 
   parts.push(`### End Memory Anchor
 The above context represents persistent memory from Honcho.
-When summarizing this conversation, ensure these facts are preserved.`);
+When summarizing this conversation, ensure these conclusions are preserved.`);
 
   return parts.join("\n\n");
 }

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -1,6 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
-import { basename } from "path";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import { Spinner } from "../spinner.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { formatVerboseBlock, formatVerboseList } from "../visual.js";
@@ -12,14 +11,6 @@ interface HookInput {
   cwd?: string;
   trigger?: "manual" | "auto";
   custom_instructions?: string;
-}
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
 /**

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,7 +1,6 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import { existsSync, readFileSync } from "fs";
-import { basename } from "path";
 import {
   getQueuedMessages,
   markMessagesUploaded,
@@ -31,14 +30,6 @@ interface TranscriptEntry {
   // Alternative format sometimes seen
   role?: string;
   content?: string | Array<{ type: string; text?: string }>;
-}
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
 /**

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -342,7 +342,6 @@ export async function handleSessionEnd(): Promise<void> {
 
     const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
     logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful), ${queuedMessages.length} queued msgs`);
-    console.log(`[honcho] Session saved: ${assistantMessages.length} assistant messages (${meaningfulCount} with meaningful prose), ${queuedMessages.length} queued messages`);
     process.exit(0);
   } catch (error) {
     logHook("session-end", `Error: ${error}`, { error: String(error) });

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -285,15 +285,15 @@ export async function handleSessionStart(): Promise<void> {
     // Reduced from 6+ overlapping sections to 2-3 focused sections
     // (as recommended in FEEDBACK-FROM-CLAUDE.md)
 
-    // Section 1: User Profile + Key Facts (CONSOLIDATED)
+    // Section 1: User Profile + Conclusions (CONSOLIDATED)
     // Combines: peerCard and representation
-    // Skips redundant "AI Summary" dialectic if we have good facts
+    // Skips redundant "AI Summary" dialectic if we have good conclusions
     if (userContextResult.status === "fulfilled" && userContextResult.value) {
       const context = userContextResult.value as any;
       setCachedUserContext(context); // Cache for user-prompt hook
       const rep = context.representation;
-      const repFactCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      logCache("write", "userContext", `${repFactCount} facts`);
+      const repConclusionCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
+      logCache("write", "userContext", `${repConclusionCount} conclusions`);
 
       const userSection: string[] = [];
 
@@ -302,7 +302,7 @@ export async function handleSessionStart(): Promise<void> {
         userSection.push(peerCard.join("\n"));
       }
 
-      // Add key facts (session-scoped, so should be relevant)
+      // Add conclusions (session-scoped, so should be relevant)
       if (rep) {
         const repText = formatRepresentation(rep);
         if (repText) {
@@ -316,14 +316,14 @@ export async function handleSessionStart(): Promise<void> {
     }
 
     // Section 2: Recent Work (CONSOLIDATED)
-    // Combines: claude facts, session summary, self-reflection
+    // Combines: claude conclusions, session summary, self-reflection
     // Prioritizes concrete work items over vague summaries
     if (claudeContextResult.status === "fulfilled" && claudeContextResult.value) {
       const context = claudeContextResult.value as any;
       setCachedClaudeContext(context); // Cache
       const rep = context.representation;
-      const claudeRepFactCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      logCache("write", "claudeContext", `${claudeRepFactCount} facts`);
+      const claudeRepConclusionCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
+      logCache("write", "claudeContext", `${claudeRepConclusionCount} conclusions`);
 
       if (rep) {
         const repText = formatRepresentation(rep);
@@ -340,7 +340,7 @@ export async function handleSessionStart(): Promise<void> {
       if (shortSummary?.content) {
         contextParts.push(`## Recent Session Summary\n${shortSummary.content}`);
       }
-      // Skip long_summary - it overlaps with facts and adds too many tokens
+      // Skip long_summary - it overlaps with conclusions and adds too many tokens
     }
 
     // AI dialectic summaries - always include when available

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -263,8 +263,10 @@ export async function handleSessionStart(): Promise<void> {
     const successCount = asyncResults.filter(r => r.success).length;
     logAsync("context-fetch", `Completed: ${successCount}/5 succeeded in ${fetchDuration}ms`, asyncResults);
 
-    // ========== VERBOSE OUTPUT (Ctrl+O) ==========
-    // Show raw API response data for debugging/inspection
+    // ========== VERBOSE OUTPUT (file-based) ==========
+    // Written to ~/.honcho/verbose.log — NOT shown in Ctrl+O.
+    // SessionStart stdout is always visible to Claude, so we can't
+    // use stdout for debug data. View with: tail -f ~/.honcho/verbose.log
     if (userContextResult.status === "fulfilled" && userContextResult.value) {
       const ctx = userContextResult.value as any;
       verboseApiResult("peer.context(user) → representation", ctx.representation);

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,6 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
-import { basename } from "path";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import {
   setCachedUserContext,
   setCachedClaudeContext,
@@ -23,14 +22,6 @@ interface HookInput {
   transcript_path?: string;
   cwd?: string;
   source?: string;
-}
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
 function formatRepresentation(rep: any): string {

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -1,6 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
-import { basename } from "path";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import { getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
@@ -21,14 +20,6 @@ interface TranscriptEntry {
     content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
   };
   content?: string | Array<{ type: string; text?: string }>;
-}
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
 /**

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -4,6 +4,7 @@ import { basename } from "path";
 import { existsSync, readFileSync } from "fs";
 import { getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
+import { visStopMessage } from "../visual.js";
 
 interface HookInput {
   session_id?: string;
@@ -143,6 +144,7 @@ export async function handleStop(): Promise<void> {
 
   if (!lastMessage || !isMeaningfulContent(lastMessage)) {
     logHook("stop", `Skipping (no meaningful content)`);
+    // Don't show systemMessage for skips — too noisy since this fires every turn
     process.exit(0);
   }
 
@@ -170,6 +172,7 @@ export async function handleStop(): Promise<void> {
     ]);
 
     logHook("stop", `Assistant response saved`);
+    visStopMessage("out", `saved response (${lastMessage.length} chars)`);
   } catch (error) {
     logHook("stop", `Upload failed: ${error}`, { error: String(error) });
   }

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,6 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getHonchoClientOptions, isPluginEnabled } from "../config.js";
-import { basename } from "path";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled } from "../config.js";
 import {
   getCachedUserContext,
   isContextCacheStale,
@@ -66,14 +65,6 @@ function shouldSkipContextRetrieval(prompt: string): boolean {
   return SKIP_CONTEXT_PATTERNS.some((p) => p.test(prompt.trim()));
 }
 
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
-}
 
 export async function handleUserPrompt(): Promise<void> {
   const config = loadConfig();

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -141,7 +141,9 @@ export async function handleUserPrompt(): Promise<void> {
     // Use cached context - instant response
     logCache("hit", "userContext", "using cached");
 
-    // Verbose output (Ctrl+O) — show what's in the cache
+    // Verbose output (file-based — ~/.honcho/verbose.log)
+    // UserPromptSubmit stdout is always visible to Claude, so we use
+    // the log file for debug data. View with: tail -f ~/.honcho/verbose.log
     const cachedRep = cachedContext?.representation;
     verboseApiResult("session.context() → representation (cached)", cachedRep);
     verboseList("session.context() → peerCard (cached)", cachedContext?.peerCard);
@@ -271,7 +273,8 @@ async function fetchFreshContext(config: any, cwd: string, prompt: string): Prom
     setCachedUserContext(contextResult); // Update cache
     const rep = (contextResult as any).representation;
 
-    // Verbose output (Ctrl+O) — show raw API response
+    // Verbose output (file-based — ~/.honcho/verbose.log)
+    // UserPromptSubmit stdout is always visible, so debug data goes to file.
     verboseApiResult("session.context() → representation", rep);
     verboseList("session.context() → peerCard", (contextResult as any).peerCard);
 

--- a/plugins/honcho/src/log.ts
+++ b/plugins/honcho/src/log.ts
@@ -11,6 +11,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { existsSync, appendFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { symbols, arrows, box } from "./unicode.js";
+import { isLoggingEnabled } from "./config.js";
 
 const CACHE_DIR = join(homedir(), ".honcho");
 const LOG_FILE = join(CACHE_DIR, "activity.log");
@@ -118,6 +119,7 @@ export function logActivity(
   data?: any,
   options?: { timing?: number; success?: boolean; depth?: number; cwd?: string; session?: string }
 ): void {
+  if (!isLoggingEnabled()) return;
   ensureLogDir();
 
   const entry: LogEntry = {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -5,16 +5,7 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getHonchoClientOptions, getSessionForPath } from "../config.js";
-import { basename } from "path";
-
-function getSessionName(cwd: string): string {
-  const configuredSession = getSessionForPath(cwd);
-  if (configuredSession) {
-    return configuredSession;
-  }
-  return basename(cwd).toLowerCase().replace(/[^a-z0-9-_]/g, "-");
-}
+import { loadConfig, getHonchoClientOptions, getSessionName } from "../config.js";
 
 export async function runMcpServer(): Promise<void> {
   const config = loadConfig();

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -53,14 +53,14 @@ export function visMessage(direction: HookDirection, hookName: string, message: 
  * Used by user-prompt hook (which outputs JSON systemMessage — works)
  */
 export function visContextLine(hookName: string, opts: {
-  facts?: number;
+  conclusions?: number;
   insights?: number;
   cached?: boolean;
   cacheAge?: number;
   sections?: number;
 }): string {
   const parts: string[] = [];
-  if (opts.facts) parts.push(`${opts.facts} facts`);
+  if (opts.conclusions) parts.push(`${opts.conclusions} conclusions`);
   if (opts.insights) parts.push(`${opts.insights} insights`);
   if (opts.sections) parts.push(`${opts.sections} sections`);
 

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -11,6 +11,7 @@
  */
 
 import { arrows, symbols } from "./unicode.js";
+import { isLoggingEnabled } from "./config.js";
 
 // Plain text (no ANSI) for systemMessage — shown in Claude Code's UI
 const sym = {
@@ -131,6 +132,7 @@ function ensureVerboseLog(): void {
 }
 
 function writeVerbose(text: string): void {
+  if (!isLoggingEnabled()) return;
   ensureVerboseLog();
   const timestamp = new Date().toISOString().split("T")[1].split(".")[0];
   appendFileSync(VERBOSE_LOG, `[${timestamp}] ${text}\n`);
@@ -163,6 +165,7 @@ export function verboseList(label: string, items: string[] | null | undefined): 
  * Clear the verbose log (call at session start)
  */
 export function clearVerboseLog(): void {
+  if (!isLoggingEnabled()) return;
   ensureVerboseLog();
   writeFileSync(VERBOSE_LOG, "");
 }

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -1,0 +1,166 @@
+/**
+ * Visual logging for honcho hooks
+ *
+ * Only hooks that output JSON with `systemMessage` show inline indicators in Claude Code:
+ * - UserPromptSubmit — addSystemMessage() adds to existing JSON output
+ * - PostToolUse — visCapture() outputs JSON with systemMessage
+ * - Stop — visStopMessage() outputs JSON with systemMessage
+ *
+ * SessionStart, SessionEnd, and PreCompact output plain text to stdout (context injection),
+ * so they cannot show inline indicators. Their activity is logged to the verbose log file only.
+ */
+
+import { arrows, symbols } from "./unicode.js";
+
+// Plain text (no ANSI) for systemMessage — shown in Claude Code's UI
+const sym = {
+  left: arrows.left,      // ←
+  right: arrows.right,    // →
+  check: symbols.check,   // ✓
+  bullet: symbols.bullet, // •
+  cross: symbols.cross,   // ✗
+};
+
+type HookDirection = "in" | "out" | "info" | "ok" | "warn" | "error";
+
+const directionSymbol: Record<HookDirection, string> = {
+  in:    sym.left,
+  out:   sym.right,
+  info:  sym.bullet,
+  ok:    sym.check,
+  warn:  "!",
+  error: sym.cross,
+};
+
+/**
+ * Format a visual log line (plain text, no ANSI — for systemMessage display)
+ */
+function formatLine(direction: HookDirection, hookName: string, message: string): string {
+  return `[honcho] ${hookName} ${directionSymbol[direction]} ${message}`;
+}
+
+/**
+ * Output a systemMessage JSON to stdout — shown to the user in Claude Code's UI
+ * Use this for hooks that don't already write to stdout (PostToolUse, Stop)
+ */
+export function visMessage(direction: HookDirection, hookName: string, message: string): void {
+  const line = formatLine(direction, hookName, message);
+  console.log(JSON.stringify({ systemMessage: line }));
+}
+
+/**
+ * Build context injection details string
+ * Used by user-prompt hook (which outputs JSON systemMessage — works)
+ */
+export function visContextLine(hookName: string, opts: {
+  facts?: number;
+  insights?: number;
+  cached?: boolean;
+  cacheAge?: number;
+  sections?: number;
+}): string {
+  const parts: string[] = [];
+  if (opts.facts) parts.push(`${opts.facts} facts`);
+  if (opts.insights) parts.push(`${opts.insights} insights`);
+  if (opts.sections) parts.push(`${opts.sections} sections`);
+
+  let suffix = "";
+  if (opts.cached) {
+    const age = opts.cacheAge ? ` ${opts.cacheAge}s ago` : "";
+    suffix = ` (cached${age})`;
+  }
+
+  if (parts.length > 0) {
+    return formatLine("in", hookName, `injected ${parts.join(", ")}${suffix}`);
+  }
+  return "";
+}
+
+/**
+ * Output tool capture as systemMessage (for post-tool-use — no existing stdout)
+ */
+export function visCapture(summary: string): void {
+  visMessage("out", "post-tool-use", `captured: ${summary}`);
+}
+
+/**
+ * Output skip as systemMessage (for hooks with no existing stdout)
+ */
+export function visSkipMessage(hookName: string, reason: string): void {
+  visMessage("info", hookName, `skipped (${reason})`);
+}
+
+/**
+ * Output stop hook message as systemMessage (no existing stdout)
+ * Named "response" in display — "stop" fires after every Claude turn, not session end
+ */
+export function visStopMessage(direction: HookDirection, message: string): void {
+  visMessage(direction, "response", message);
+}
+
+/**
+ * Add systemMessage to an existing hookSpecificOutput JSON object
+ * Used by UserPromptSubmit which already outputs JSON
+ */
+export function addSystemMessage(existingJson: any, message: string): any {
+  return { ...existingJson, systemMessage: message };
+}
+
+// ============================================
+// Verbose output — written to ~/.honcho/verbose.log
+// Tail with: tail -f ~/.honcho/verbose.log
+// ============================================
+
+import { homedir } from "os";
+import { join } from "path";
+import { appendFileSync, mkdirSync, existsSync, writeFileSync } from "fs";
+
+const VERBOSE_LOG = join(homedir(), ".honcho", "verbose.log");
+
+function ensureVerboseLog(): void {
+  const dir = join(homedir(), ".honcho");
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeVerbose(text: string): void {
+  ensureVerboseLog();
+  const timestamp = new Date().toISOString().split("T")[1].split(".")[0];
+  appendFileSync(VERBOSE_LOG, `[${timestamp}] ${text}\n`);
+}
+
+/**
+ * Log detailed API response data to verbose log file.
+ * View with: tail -f ~/.honcho/verbose.log
+ */
+export function verboseApiResult(label: string, data: string | null | undefined): void {
+  if (!data) return;
+  const separator = "─".repeat(60);
+  const content = data.length > 3000 ? data.slice(0, 3000) + `\n... (${data.length - 3000} more chars)` : data;
+  writeVerbose(`${label}\n${separator}\n${content}\n${separator}`);
+}
+
+/**
+ * Log a list of items (like peerCard) to verbose log file.
+ */
+export function verboseList(label: string, items: string[] | null | undefined): void {
+  if (!items || items.length === 0) return;
+  const formatted = items.map(item => `  • ${item}`).join("\n");
+  writeVerbose(`${label} (${items.length} items)\n${formatted}`);
+}
+
+/**
+ * Clear the verbose log (call at session start)
+ */
+export function clearVerboseLog(): void {
+  ensureVerboseLog();
+  writeFileSync(VERBOSE_LOG, "");
+}
+
+/**
+ * Get the verbose log path
+ */
+export function getVerboseLogPath(): string {
+  return VERBOSE_LOG;
+}


### PR DESCRIPTION
Remove all legacy Honcho SDK v1 format handling to standardize on SDK v2 string-based representations. Add visual logging module for hook UI integration.

Legacy format removal:
- Remove sortByRecency() helper functions from session-start.ts and user-prompt.ts (only needed for legacy explicit/deductive arrays)
- Remove explicit[]/deductive[] array handling from formatRepresentation(), formatCachedContext(), fetchFreshContext(), and formatMemoryCard()
- Remove peer_card fallback (now only peerCard)
- Remove short_summary fallback (now only shortSummary)
- Remove peerRepresentation fallback (now only representation)
- Simplify formatRepresentation() to only handle string representations
- Remove insightCount from FreshContextResult interface (no longer tracked separately from factCount)
- Update fact counting to use line-based counting on markdown strings instead of array .length

Visual logging additions:
- Add new visual.ts module for hook UI integration with verbose logging, formatted API responses, system messages, and directional indicators
- Import and use visual logging across all hooks:
  - session-start.ts: verbose API result output, peerCard display, clear verbose log on session start
  - user-prompt.ts: context injection status lines, skip messages, system messages for cache hits/misses/failures
  - pre-compact.ts: verbose output for peer context and peerCard
  - post-tool-use.ts: capture summaries via visCapture()
  - stop.ts: response save confirmation via visStopMessage()

Other changes:
- session-end.ts: remove redundant console.log (already logged via logHook)
- user-prompt.ts: add outputSystemOnly() for error/skip status messages, add systemMsg parameter to outputContext() for visual status lines
- stop.ts: add comment clarifying skip behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich visual/system messages for hook events, context injection, skips, tool-use captures, and stop responses.
  * Post-tool-use capture and inline context lines for clearer runtime visibility.
  * Verbose diagnostics with a dedicated verbose log and formatted verbose output (Ctrl+O visibility).

* **Chores**
  * Centralized session naming and simplified context formatting.
  * Runtime toggle for file logging (env variable) and package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->