### PR TITLE
fix: syntax fix

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -606,7 +606,7 @@ export function truncateToTokens(text: string, maxTokens: number): string {
 
 export interface HonchoClientOptions {
   apiKey: string;
-  baseUrl: string;
+  baseURL: string;
   workspaceId: string;
 }
 
@@ -625,7 +625,7 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
-    baseUrl: getHonchoBaseUrl(config),
+    baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
   };
 }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -385,7 +385,7 @@ export async function handleSessionStart(): Promise<void> {
         linkedWorkspaces.map(async (ws) => {
           const linkedClient = new Honcho({
             apiKey: config.apiKey,
-            baseUrl: getHonchoBaseUrl(config),
+            baseURL: getHonchoBaseUrl(config),
             workspaceId: ws,
           });
           const linkedPeer = await linkedClient.peer(config.peerName);

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -306,7 +306,7 @@ async function fetchFreshContext(config: any, cwd: string, prompt: string): Prom
       linkedWorkspaces.map(async (ws) => {
         const linkedClient = new Honcho({
           apiKey: config.apiKey,
-          baseUrl: getHonchoBaseUrl(config),
+          baseURL: getHonchoBaseUrl(config),
           workspaceId: ws,
         });
         const linkedSession = await linkedClient.session(sessionName);


### PR DESCRIPTION
Based on this bug report: https://github.com/plastic-labs/honcho/issues/420

Fixes the baseURL syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Honcho client configuration field naming convention from `baseUrl` to `baseURL` throughout the plugin and across all client instantiation locations. This update affects configuration option setup, session management client initialization, and user prompt context operations within the Honcho plugin. All references now consistently utilize the corrected field name `baseURL` instead of the previous `baseUrl`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->