### PR TITLE
fix: resilient context refresh, per-host config, session-end hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Honcho Banner](./assets/honcho_clawd.png)](https://honcho.dev)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Version](https://img.shields.io/badge/version-0.2.3-blue)](https://github.com/plastic-labs/claude-honcho)
 [![Honcho](https://img.shields.io/badge/Honcho-Memory%20API-blue)](https://honcho.dev)
 
 A plugin marketplace for Claude Code, powered by [Honcho](https://honcho.dev) from Plastic Labs.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://bun.sh/install | bash
 
 ### Step 2: Set Environment Variables
 
-Add these to your shell config (`~/.zshrc`, `~/.bashrc`, or `~/.profile`):
+**macOS / Linux** -- add these to your shell config (`~/.zshrc`, `~/.bashrc`, or `~/.profile`):
 
 ```bash
 # Required
@@ -75,6 +75,19 @@ Then reload your shell:
 ```bash
 source ~/.zshrc  # or ~/.bashrc
 ```
+
+**Windows (PowerShell)** -- set a persistent user environment variable:
+
+```powershell
+# Required
+[Environment]::SetEnvironmentVariable("HONCHO_API_KEY", "hch-your-api-key-here", "User")
+
+# Optional
+[Environment]::SetEnvironmentVariable("HONCHO_PEER_NAME", $env:USERNAME, "User")
+[Environment]::SetEnvironmentVariable("HONCHO_WORKSPACE", "claude_code", "User")
+```
+
+Then restart your terminal so the new variables take effect.
 
 ### Step 3: Install the Plugin
 
@@ -383,10 +396,11 @@ The plugin hooks into Claude Code's lifecycle events:
 1. **Check your API key is set:**
 
    ```bash
-   echo $HONCHO_API_KEY
+   echo $HONCHO_API_KEY          # macOS / Linux
+   echo $env:HONCHO_API_KEY      # Windows PowerShell
    ```
 
-   If empty, add it to your shell config and `source` it.
+   If empty, set it (see Step 2 in Quick Start) and restart your terminal.
 
 2. **Check the plugin is installed:**
 

--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -41,7 +41,7 @@
           {
             "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
-            "timeout": 15000
+            "timeout": 7000
           }
         ]
       }

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-honcho",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "type": "module",
   "keywords": [

--- a/plugins/honcho/scripts/install-local.ps1
+++ b/plugins/honcho/scripts/install-local.ps1
@@ -1,0 +1,120 @@
+# Install the local plugin source into Claude Code's plugin cache.
+# Run from anywhere -- paths are absolute.
+# After running, restart Claude Code to pick up changes.
+#
+# Usage:  powershell -ExecutionPolicy Bypass -File install-local.ps1
+
+$ErrorActionPreference = "Stop"
+
+$PluginDir = (Resolve-Path "$PSScriptRoot\..").Path
+$CacheBase = Join-Path $env:USERPROFILE ".claude\plugins\cache\honcho\honcho"
+$MarketplaceDir = Join-Path $env:USERPROFILE ".claude\plugins\marketplaces\honcho\plugins\honcho"
+$InstalledJson = Join-Path $env:USERPROFILE ".claude\plugins\installed_plugins.json"
+
+# ---------------------------------------------------------------------------
+# Verify bun is available
+# ---------------------------------------------------------------------------
+if (-not (Get-Command bun -ErrorAction SilentlyContinue)) {
+    Write-Host "  ERROR: bun is not installed or not in PATH" -ForegroundColor Red
+    Write-Host "  Install it from https://bun.sh/docs/installation" -ForegroundColor Red
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Read version from package.json
+# ---------------------------------------------------------------------------
+$PkgJson = Get-Content (Join-Path $PluginDir "package.json") -Raw | ConvertFrom-Json
+$Version = $PkgJson.version
+
+# ---------------------------------------------------------------------------
+# Determine cache target -- match installed version if present
+# ---------------------------------------------------------------------------
+$InstalledVersion = ""
+if (Test-Path $InstalledJson) {
+    $Installed = Get-Content $InstalledJson -Raw | ConvertFrom-Json
+    $Entries = $Installed.plugins.'honcho@honcho'
+    if ($Entries -and $Entries.Count -gt 0) {
+        $InstalledVersion = $Entries[0].version
+    }
+}
+
+if ($InstalledVersion) {
+    $CacheDir = Join-Path $CacheBase $InstalledVersion
+} else {
+    $CacheDir = Join-Path $CacheBase $Version
+}
+
+Write-Host ""
+Write-Host "  plugin source:  $PluginDir"
+Write-Host "  cache target:   $CacheDir"
+Write-Host "  version:        $Version"
+Write-Host ""
+
+# ---------------------------------------------------------------------------
+# Ensure dependencies are installed
+# ---------------------------------------------------------------------------
+if (-not (Test-Path (Join-Path $PluginDir "node_modules"))) {
+    Write-Host "  installing dependencies..."
+    Push-Location $PluginDir
+    bun install --frozen-lockfile
+    Pop-Location
+    Write-Host ""
+}
+
+# ---------------------------------------------------------------------------
+# Sync files to cache (mirrors rsync --delete, excluding dev artifacts)
+# ---------------------------------------------------------------------------
+$Excludes = @(".git", "scripts", ".DS_Store")
+
+if (Test-Path $CacheDir) {
+    Remove-Item $CacheDir -Recurse -Force
+}
+New-Item -ItemType Directory -Path $CacheDir -Force | Out-Null
+
+# Copy everything, then remove excluded dirs
+Copy-Item "$PluginDir\*" $CacheDir -Recurse -Force
+
+foreach ($ex in $Excludes) {
+    $target = Join-Path $CacheDir $ex
+    if (Test-Path $target) {
+        Remove-Item $target -Recurse -Force
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Sync skills + plugin manifest to marketplace (if marketplace dir exists)
+# ---------------------------------------------------------------------------
+if (Test-Path $MarketplaceDir) {
+    Write-Host "  syncing marketplace skills..."
+
+    $SkillsDest = Join-Path $MarketplaceDir "skills"
+    if (Test-Path $SkillsDest) { Remove-Item $SkillsDest -Recurse -Force }
+    Copy-Item (Join-Path $PluginDir "skills") $SkillsDest -Recurse -Force
+
+    $ManifestSrc = Join-Path $PluginDir ".claude-plugin"
+    $ManifestDest = Join-Path $MarketplaceDir ".claude-plugin"
+    Copy-Item "$ManifestSrc\*" $ManifestDest -Force
+}
+
+# ---------------------------------------------------------------------------
+# Update installed_plugins.json if version changed
+# ---------------------------------------------------------------------------
+if ((Test-Path $InstalledJson) -and $InstalledVersion -and ($InstalledVersion -ne $Version)) {
+    Write-Host "  updating installed_plugins.json ($InstalledVersion -> $Version)"
+
+    $NewCache = Join-Path $CacheBase $Version
+    if ($CacheDir -ne $NewCache) {
+        Rename-Item $CacheDir $NewCache
+        $CacheDir = $NewCache
+    }
+
+    $Installed = Get-Content $InstalledJson -Raw | ConvertFrom-Json
+    $Entry = $Installed.plugins.'honcho@honcho'[0]
+    $Entry.version = $Version
+    $Entry.installPath = $CacheDir
+    $Entry.lastUpdated = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffZ")
+    $Installed | ConvertTo-Json -Depth 10 | Set-Content $InstalledJson -Encoding UTF8
+}
+
+Write-Host ""
+Write-Host "  done -- restart Claude Code to load changes" -ForegroundColor Green

--- a/plugins/honcho/skills/setup/SKILL.md
+++ b/plugins/honcho/skills/setup/SKILL.md
@@ -11,46 +11,70 @@ Walk the user through first-time Honcho configuration so persistent memory works
 
 ### 1. Check current state
 
-Run this command to check if `HONCHO_API_KEY` is already set:
+Check if `HONCHO_API_KEY` is set as an environment variable OR if `~/.honcho/config.json` already has an apiKey:
 
 ```bash
-echo "${HONCHO_API_KEY:+set}"
+bun -e "
+const fs = require('fs');
+const path = require('path');
+const configPath = path.join(require('os').homedir(), '.honcho', 'config.json');
+const envKey = process.env.HONCHO_API_KEY;
+let configKey = '';
+try { configKey = JSON.parse(fs.readFileSync(configPath, 'utf-8')).apiKey || ''; } catch {}
+console.log(envKey || configKey ? 'set' : 'not set');
+"
 ```
 
 If the output is `set`, skip to step 3 (validation). Otherwise continue.
 
-### 2. Direct user to get an API key
+### 2. Direct user to set their API key
 
-Tell the user:
+Tell the user to get a free API key at https://app.honcho.dev, then set it as an environment variable.
 
-> You need a Honcho API key. Get one for free at https://app.honcho.dev
->
-> Once you have it, add this line to your shell config (`~/.zshrc` or `~/.bashrc`):
+Detect the platform and give the appropriate command:
+
+**If Windows** (check with `bun -e "console.log(process.platform)"` if unsure):
+
+> Set your API key in PowerShell:
+> ```powershell
+> setx HONCHO_API_KEY "your-key-here"
+> ```
+> Then restart Claude Code and run `/honcho:setup` again.
+
+**If macOS / Linux:**
+
+> Add to your shell config (`~/.zshrc` or `~/.bashrc`):
 > ```
 > export HONCHO_API_KEY="your-key-here"
 > ```
->
-> Then restart Claude Code so it picks up the new environment variable.
+> Then restart Claude Code and run `/honcho:setup` again.
 
-Wait for the user to confirm they have set the key. If they paste the key directly in chat, warn them not to share API keys in conversation and remind them to set it as an environment variable instead.
+IMPORTANT: Do NOT ask the user to paste their API key into the chat. Keys must be set via environment variable outside of Claude Code.
+
+Stop here and wait for the user to come back after restarting. Do not proceed to validation until the user runs `/honcho:setup` again.
 
 ### 3. Validate the API key
 
-Test the connection by running the setup runner. Find the plugin directory first:
+Run the setup runner to validate the connection:
 
 ```bash
-HONCHO_PLUGIN="${HONCHO_PLUGIN_DIR:-$HOME/.honcho/plugins/claude-honcho/plugins/honcho}"
-bun run "$HONCHO_PLUGIN/src/skills/setup-runner.ts"
+bun run "${CLAUDE_PLUGIN_ROOT}/src/skills/setup-runner.ts"
 ```
 
-If it succeeds, the key is valid and the config file has been created.
+If `CLAUDE_PLUGIN_ROOT` is not set, resolve the path:
+
+```bash
+bun -e "const h=require('os').homedir();const p=require('path');console.log(p.join(h,'.claude','plugins','cache','honcho','honcho'))"
+```
+
+Then find the version directory inside that path and run the setup runner from there.
+
+If it succeeds, the key is valid and the full config file has been created.
 
 If it fails, help the user troubleshoot:
-- Key not set: re-check shell config and restart Claude Code
 - Authentication error: key may be invalid, get a new one from https://app.honcho.dev
 - Network error: check internet connection
-- Plugin not found: check that claude-honcho is installed at `~/.honcho/plugins/claude-honcho`
 
 ### 4. Confirm setup
 
-Tell the user that Honcho is configured and memory will be active on their next session. Suggest they restart Claude Code or open a new chat to see the memory context load.
+Tell the user that Honcho is configured and memory will be active on their next session. Suggest they restart Claude Code to see the memory context load.

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -136,13 +136,30 @@ function getMessageRefreshThreshold(): number {
   return config.messageThreshold ?? 50;
 }
 
+// Known keys in ContextCache — anything else is a ghost from older versions
+const CONTEXT_CACHE_KNOWN_KEYS = new Set([
+  "userContext", "claudeContext", "summaries", "messageCount", "lastRefreshMessageCount",
+]);
+
 export function loadContextCache(): ContextCache {
   ensureCacheDir();
   if (!existsSync(CONTEXT_CACHE_FILE)) {
     return {};
   }
   try {
-    return JSON.parse(readFileSync(CONTEXT_CACHE_FILE, "utf-8"));
+    const raw = JSON.parse(readFileSync(CONTEXT_CACHE_FILE, "utf-8"));
+    // Strip ghost keys left by older plugin versions (e.g. "aiContext")
+    let cleaned = false;
+    for (const key of Object.keys(raw)) {
+      if (!CONTEXT_CACHE_KNOWN_KEYS.has(key)) {
+        delete raw[key];
+        cleaned = true;
+      }
+    }
+    if (cleaned) {
+      writeFileSync(CONTEXT_CACHE_FILE, JSON.stringify(raw, null, 2));
+    }
+    return raw;
   } catch {
     return {};
   }
@@ -199,6 +216,11 @@ export function incrementMessageCount(): number {
   cache.messageCount = (cache.messageCount || 0) + 1;
   saveContextCache(cache);
   return cache.messageCount;
+}
+
+export function getMessageCount(): number {
+  const cache = loadContextCache();
+  return cache.messageCount || 0;
 }
 
 export function shouldRefreshKnowledgeGraph(): boolean {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -31,6 +31,8 @@ export interface LocalContextConfig {
   maxEntries?: number;
 }
 
+export type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "max";
+
 export type SessionStrategy = "per-directory" | "git-branch" | "chat-instance";
 
 export type HonchoEnvironment = "production" | "local";
@@ -60,6 +62,18 @@ export interface HostConfig {
   aiPeer?: string;
   /** Other host keys whose workspaces to read context from (writes stay local) */
   linkedHosts?: string[];
+  /** Per-host overrides for settings that may differ across tools */
+  enabled?: boolean;
+  logging?: boolean;
+  saveMessages?: boolean;
+  sessionStrategy?: SessionStrategy;
+  sessionPeerPrefix?: boolean;
+  /** Default reasoning level for Honcho dialectic calls (default: "medium") */
+  reasoningLevel?: ReasoningLevel;
+  messageUpload?: MessageUploadConfig;
+  contextRefresh?: ContextRefreshConfig;
+  localContext?: LocalContextConfig;
+  endpoint?: HonchoEndpointConfig;
 }
 
 let _detectedHost: HonchoHost | null = null;
@@ -150,6 +164,8 @@ interface HonchoFileConfig {
   sessionStrategy?: SessionStrategy;
   /** Prefix session names with peerName (default: true, disable for solo use) */
   sessionPeerPrefix?: boolean;
+  /** Default reasoning level for Honcho dialectic calls (default: "medium") */
+  reasoningLevel?: ReasoningLevel;
   hosts?: Record<string, HostConfig>;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts,
    *  ignoring host-specific blocks. When false (default), each host
@@ -182,6 +198,8 @@ export interface HonchoCLAUDEConfig {
   sessions?: Record<string, string>;
   /** Save messages to Honcho (default: true) */
   saveMessages?: boolean;
+  /** Default reasoning level for Honcho dialectic calls (default: "medium") */
+  reasoningLevel?: ReasoningLevel;
   /** Token-based upload limits */
   messageUpload?: MessageUploadConfig;
   /** Context retrieval settings */
@@ -196,6 +214,20 @@ export interface HonchoCLAUDEConfig {
   logging?: boolean;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a == null || b == null) return a === b;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== "object") return false;
+  const aObj = a as Record<string, unknown>;
+  const bObj = b as Record<string, unknown>;
+  const keys = new Set([...Object.keys(aObj), ...Object.keys(bObj)]);
+  for (const key of keys) {
+    if (!deepEqual(aObj[key], bObj[key])) return false;
+  }
+  return true;
 }
 
 const CONFIG_DIR = join(homedir(), ".honcho");
@@ -236,13 +268,15 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
   const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
   if (!apiKey) return null;
 
-  const peerName = raw.peerName || process.env.HONCHO_PEER_NAME || process.env.USER || "user";
+  const peerName = raw.peerName || process.env.HONCHO_PEER_NAME || process.env.USER || process.env.USERNAME || "user";
 
   // Resolve host-specific fields
   let workspace: string;
   let aiPeer: string;
 
-  const hostBlock = raw.hosts?.[host];
+  const hostBlock = raw.hosts?.[host]
+    ?? raw.hosts?.[host.replace(/_/g, "-")]
+    ?? raw.hosts?.[host.replace(/-/g, "_")];
 
   if (raw.globalOverride === true) {
     // Global override: flat fields apply to ALL hosts
@@ -268,22 +302,26 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
   // Resolve linked hosts
   const linkedHosts = hostBlock?.linkedHosts ?? [];
 
+  // Per-host settings: check hosts.<name>.X first, fall back to root X.
+  // This lets the user set global defaults at root (via CLI) while
+  // individual integrations can override per-host without touching root.
   const config: HonchoCLAUDEConfig = {
     apiKey,
     peerName,
     workspace,
     aiPeer,
     linkedHosts: linkedHosts.length ? linkedHosts : undefined,
-    sessionStrategy: raw.sessionStrategy,
-    sessionPeerPrefix: raw.sessionPeerPrefix,
+    sessionStrategy: hostBlock?.sessionStrategy ?? raw.sessionStrategy,
+    sessionPeerPrefix: hostBlock?.sessionPeerPrefix ?? raw.sessionPeerPrefix,
     sessions: raw.sessions,
-    saveMessages: raw.saveMessages,
-    messageUpload: raw.messageUpload,
-    contextRefresh: raw.contextRefresh,
-    endpoint: raw.endpoint,
-    localContext: raw.localContext,
-    enabled: raw.enabled,
-    logging: raw.logging,
+    saveMessages: hostBlock?.saveMessages ?? raw.saveMessages,
+    reasoningLevel: hostBlock?.reasoningLevel ?? raw.reasoningLevel,
+    messageUpload: hostBlock?.messageUpload ?? raw.messageUpload,
+    contextRefresh: hostBlock?.contextRefresh ?? raw.contextRefresh,
+    endpoint: hostBlock?.endpoint ?? raw.endpoint,
+    localContext: hostBlock?.localContext ?? raw.localContext,
+    enabled: hostBlock?.enabled ?? raw.enabled,
+    logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
   };
 
@@ -302,7 +340,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
   }
 
   const resolvedHost = host ?? getDetectedHost();
-  const peerName = process.env.HONCHO_PEER_NAME || process.env.USER || "user";
+  const peerName = process.env.HONCHO_PEER_NAME || process.env.USER || process.env.USERNAME || "user";
   const workspace = process.env.HONCHO_WORKSPACE || DEFAULT_WORKSPACE[resolvedHost];
   const hostPeerEnv = resolvedHost === "cursor"
     ? process.env.HONCHO_CURSOR_PEER
@@ -356,18 +394,24 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
 }
 
 /**
- * Read-merge-write: reads existing file, merges in changes, writes back.
- * This prevents one host from clobbering fields owned by the other.
- * Host-specific fields (workspace, aiPeer, linkedHosts) live in the
- * hosts block. Legacy flat fields (workspace, cursorPeer, claudePeer)
- * are no longer written — they may still exist in old config files but
- * are only consulted as fallbacks when the hosts block is missing.
+ * Write-back: read-merge-write to avoid clobbering other hosts' config.
+ *
+ * Convention:
+ *   - Root-level keys (apiKey, peerName, enabled, etc.) are owned by
+ *     the user or the honcho CLI.  This integration NEVER writes them.
+ *   - hosts.<this-host> is owned by this integration and carries all
+ *     per-host settings (workspace, aiPeer, enabled, logging, ...).
+ *   - sessions is shared across hosts -- written at root.
+ *
+ * resolveConfig() reads host block first, falls back to root, so the
+ * user's root-level defaults still apply until overridden per-host.
  */
 export function saveConfig(config: HonchoCLAUDEConfig): void {
   if (!existsSync(CONFIG_DIR)) {
     mkdirSync(CONFIG_DIR, { recursive: true });
   }
 
+  // Re-read from disk to avoid clobbering other tools' changes
   let existing: HonchoFileConfig = {};
   if (existsSync(CONFIG_FILE)) {
     try {
@@ -377,47 +421,85 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
     }
   }
 
-  // Merge shared fields
-  existing.apiKey = config.apiKey;
-  existing.peerName = config.peerName;
-  existing.sessionStrategy = config.sessionStrategy;
-  existing.sessionPeerPrefix = config.sessionPeerPrefix;
-  existing.sessions = config.sessions;
-  existing.saveMessages = config.saveMessages;
-  existing.messageUpload = config.messageUpload;
-  existing.contextRefresh = config.contextRefresh;
-  existing.endpoint = config.endpoint;
-  existing.localContext = config.localContext;
-  existing.enabled = config.enabled;
-  existing.logging = config.logging;
+  // Sessions are shared across hosts -- write at root
+  if (config.sessions !== undefined) {
+    existing.sessions = config.sessions;
+  }
 
-  // Write host-specific fields into hosts block
+  // Everything else goes in the host block.
+  // Keep workspace/aiPeer host-local, but avoid materializing root defaults
+  // into new host overrides. This preserves root fallback behavior.
   const host = getDetectedHost();
   if (!existing.hosts) existing.hosts = {};
-  existing.hosts[host] = {
-    workspace: config.workspace,
-    aiPeer: config.aiPeer,
-    ...(config.linkedHosts?.length ? { linkedHosts: config.linkedHosts } : {}),
+  const existingHost: HostConfig = existing.hosts[host] ?? {};
+
+  const hostEntry: HostConfig = {};
+  if (config.linkedHosts?.length) hostEntry.linkedHosts = config.linkedHosts;
+
+  const setHostIfExplicit = <K extends keyof HostConfig>(
+    key: K,
+    value: HostConfig[K],
+    rootValue: unknown
+  ) => {
+    if (value === undefined) return;
+    const hasHostOverride = Object.prototype.hasOwnProperty.call(existingHost, key);
+    if (hasHostOverride || !deepEqual(value, rootValue)) {
+      hostEntry[key] = value;
+    }
   };
 
-  // Write globalOverride when explicitly set; preserve existing value otherwise
-  if (config.globalOverride !== undefined) {
-    existing.globalOverride = config.globalOverride;
+  // Only persist workspace/aiPeer to host block if the block already had them
+  // or if they differ from the default for this host.  This prevents root
+  // fallback values from being materialized into host overrides.
+  setHostIfExplicit("workspace", config.workspace, existing.workspace ?? DEFAULT_WORKSPACE[host]);
+  setHostIfExplicit("aiPeer", config.aiPeer, existing.aiPeer ?? DEFAULT_AI_PEER[host]);
+
+  // Don't persist env-only overrides to the host block.
+  // mergeWithEnvVars() may have set enabled=false or logging=false from
+  // HONCHO_ENABLED / HONCHO_LOGGING env vars — those are runtime overrides
+  // that should not be materialized to disk.
+  const enabledForSave = process.env.HONCHO_ENABLED === "false" && config.enabled === false
+    ? existingHost.enabled  // preserve what was on disk
+    : config.enabled;
+  const loggingForSave = process.env.HONCHO_LOGGING === "false" && config.logging === false
+    ? existingHost.logging
+    : config.logging;
+
+  setHostIfExplicit("enabled", enabledForSave, existing.enabled);
+  setHostIfExplicit("logging", loggingForSave, existing.logging);
+  setHostIfExplicit("saveMessages", config.saveMessages, existing.saveMessages);
+  setHostIfExplicit("sessionStrategy", config.sessionStrategy, existing.sessionStrategy);
+  setHostIfExplicit("sessionPeerPrefix", config.sessionPeerPrefix, existing.sessionPeerPrefix);
+  setHostIfExplicit("reasoningLevel", config.reasoningLevel, existing.reasoningLevel);
+  setHostIfExplicit("messageUpload", config.messageUpload, existing.messageUpload);
+  setHostIfExplicit("contextRefresh", config.contextRefresh, existing.contextRefresh);
+  setHostIfExplicit("localContext", config.localContext, existing.localContext);
+  setHostIfExplicit("endpoint", config.endpoint, existing.endpoint);
+
+  existing.hosts[host] = hostEntry;
+
+  writeFileSync(CONFIG_FILE, JSON.stringify(existing, null, 2));
+}
+
+/**
+ * Write a single root-level field to config.json.
+ * ONLY for explicit user-directed actions (MCP set_config) on fields
+ * that are genuinely global (apiKey, peerName, globalOverride).
+ * Hooks and routine operations must NEVER call this.
+ */
+export function saveRootField(field: string, value: unknown): void {
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
   }
 
-  // Clean legacy flat fields when hosts block exists
-  if (existing.hosts && !existing.globalOverride) {
-    delete existing.cursorPeer;
-    delete existing.claudePeer;
-    // Only remove flat workspace if it duplicates a host block value
-    // (avoids breaking configs where globalOverride isn't set yet)
-    const hostWorkspaces = Object.values(existing.hosts).map((h: any) => h.workspace);
-    if (existing.workspace && hostWorkspaces.includes(existing.workspace)) {
-      delete existing.workspace;
-    }
-    delete existing.aiPeer;
+  let existing: Record<string, unknown> = {};
+  if (existsSync(CONFIG_FILE)) {
+    try {
+      existing = JSON.parse(readFileSync(CONFIG_FILE, "utf-8"));
+    } catch {}
   }
 
+  existing[field] = value;
   writeFileSync(CONFIG_FILE, JSON.stringify(existing, null, 2));
 }
 
@@ -546,35 +628,54 @@ export function setPluginEnabled(enabled: boolean): void {
 }
 
 /**
- * Get workspace names from linked hosts.
- * Returns the workspace names configured for each linked host key.
- * If a linked host has no workspace set, uses its default.
+ * Linked host workspace + endpoint resolution from raw config.
+ * Endpoint falls back to root endpoint when the host block omits it.
  */
-export function getLinkedWorkspaces(): string[] {
+export interface LinkedWorkspaceConfig {
+  hostKey: string;
+  workspace: string;
+  endpoint?: HonchoEndpointConfig;
+}
+
+export function getLinkedWorkspaceConfigs(): LinkedWorkspaceConfig[] {
   const config = loadConfig();
   if (!config?.linkedHosts?.length) return [];
 
   const cfgPath = getConfigPath();
   if (!existsSync(cfgPath)) return [];
 
-  let raw: Record<string, any>;
+  let raw: HonchoFileConfig;
   try {
-    raw = JSON.parse(readFileSync(cfgPath, "utf-8"));
+    raw = JSON.parse(readFileSync(cfgPath, "utf-8")) as HonchoFileConfig;
   } catch {
     return [];
   }
 
-  const workspaces: string[] = [];
+  const linked: LinkedWorkspaceConfig[] = [];
   for (const hostKey of config.linkedHosts) {
-    const block = raw.hosts?.[hostKey];
+    // Normalize: try exact key, then underscore, then dash variants
+    const block = raw.hosts?.[hostKey]
+      ?? raw.hosts?.[hostKey.replace(/-/g, "_")]
+      ?? raw.hosts?.[hostKey.replace(/_/g, "-")];
     // Use that host's configured workspace, or fall back to host key as workspace name
     const ws = block?.workspace ?? hostKey;
     // Don't include our own workspace
     if (ws !== config.workspace) {
-      workspaces.push(ws);
+      linked.push({
+        hostKey,
+        workspace: ws,
+        endpoint: block?.endpoint ?? raw.endpoint,
+      });
     }
   }
-  return workspaces;
+  return linked;
+}
+
+/**
+ * Get workspace names from linked hosts.
+ */
+export function getLinkedWorkspaces(): string[] {
+  return getLinkedWorkspaceConfigs().map((entry) => entry.workspace);
 }
 
 /**
@@ -608,18 +709,25 @@ export interface HonchoClientOptions {
   apiKey: string;
   baseURL: string;
   workspaceId: string;
+  timeout?: number;
+  maxRetries?: number;
 }
 
 /** Get the base URL for Honcho API. Priority: baseUrl > environment > production */
-export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
-  if (config.endpoint?.baseUrl) {
-    const url = config.endpoint.baseUrl;
+export function getHonchoBaseUrlForEndpoint(endpoint?: HonchoEndpointConfig): string {
+  if (endpoint?.baseUrl) {
+    const url = endpoint.baseUrl;
     return url.endsWith("/v3") ? url : `${url}/v3`;
   }
-  if (config.endpoint?.environment === "local") {
+  if (endpoint?.environment === "local") {
     return HONCHO_BASE_URLS.local;
   }
   return HONCHO_BASE_URLS.production;
+}
+
+/** Get the base URL for a resolved runtime config. */
+export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
+  return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
@@ -627,6 +735,8 @@ export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClient
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
+    timeout: 8000,
+    maxRetries: 1,
   };
 }
 

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -156,12 +156,12 @@ export async function handlePreCompact(): Promise<void> {
         // Fresh dialectic - ask about user (worth the cost at compaction time)
         userPeer.chat(
           `Summarize the most important things to remember about ${config.peerName}. Focus on their preferences, working style, current projects, and any critical context that should survive a conversation summary.`,
-          { session }
+          { session, reasoningLevel: config.reasoningLevel ?? "low" }
         ),
         // Fresh dialectic - claude self-reflection
         aiPeer.chat(
           `What are the most important things ${config.aiPeer} was working on with ${config.peerName}? Summarize key context that should be preserved.`,
-          { session }
+          { session, reasoningLevel: config.reasoningLevel ?? "low" }
         ),
       ]);
 

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
   getQueuedMessages,
@@ -29,20 +29,16 @@ interface TranscriptEntry {
     role?: string;
     content: string | Array<{ type: string; text?: string; name?: string; input?: any }>;
   };
-  // Alternative format sometimes seen
   role?: string;
   content?: string | Array<{ type: string; text?: string }>;
 }
 
 /**
  * Check if assistant content is meaningful prose vs just tool acknowledgment
- * We want to capture explanations, summaries, recommendations - not "I'll run git status"
  */
 function isMeaningfulAssistantContent(content: string): boolean {
-  // Skip very short responses
   if (content.length < 50) return false;
 
-  // Skip responses that are mostly tool invocation announcements
   const toolAnnouncements = [
     /^(I'll|Let me|I'm going to|I will|Now I'll|First,? I'll)\s+(run|use|execute|check|read|look at|search|edit|write|create)/i,
     /^Running\s+/i,
@@ -55,12 +51,10 @@ function isMeaningfulAssistantContent(content: string): boolean {
     }
   }
 
-  // Skip if it's just acknowledging tool results without explanation
   if (/^(The command|The file|The output|This shows|Here's what)/i.test(content.trim()) && content.length < 150) {
     return false;
   }
 
-  // Keep: explanations, summaries, recommendations, analysis
   const meaningfulPatterns = [
     /\b(because|since|therefore|however|although|this means|in summary|to summarize|the issue is|the problem is|I recommend|you should|we should|this approach|the solution|key point|important|note that)\b/i,
     /\b(implemented|fixed|resolved|completed|added|created|updated|changed|modified|refactored)\b/i,
@@ -72,7 +66,6 @@ function isMeaningfulAssistantContent(content: string): boolean {
     }
   }
 
-  // If it's long enough, probably meaningful
   return content.length >= 200;
 }
 
@@ -90,8 +83,6 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
     for (const line of lines) {
       try {
         const entry: TranscriptEntry = JSON.parse(line);
-
-        // Handle different transcript formats
         const entryType = entry.type || entry.role;
         const messageContent = entry.message?.content || entry.content;
 
@@ -112,13 +103,11 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
           if (typeof messageContent === "string") {
             assistantContent = messageContent;
           } else if (Array.isArray(messageContent)) {
-            // Extract text blocks (skip tool_use blocks - those are captured by PostToolUse)
             const textBlocks = messageContent
               .filter((p) => p.type === "text" && p.text)
               .map((p) => p.text!)
               .join("\n\n");
 
-            // Also note what tools were used for context
             const toolUses = messageContent
               .filter((p) => p.type === "tool_use")
               .map((p: any) => p.name)
@@ -126,7 +115,6 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
 
             assistantContent = textBlocks;
 
-            // If there were tool uses but minimal text, note what tools were used
             if (toolUses.length > 0 && textBlocks.length < 100) {
               assistantContent = textBlocks + (textBlocks ? "\n" : "") + `[Used tools: ${toolUses.join(", ")}]`;
             }
@@ -134,7 +122,6 @@ function parseTranscript(transcriptPath: string): Array<{ role: string; content:
 
           if (assistantContent && assistantContent.trim()) {
             const isMeaningful = isMeaningfulAssistantContent(assistantContent);
-            // Truncate but keep more of meaningful content
             const maxLen = isMeaningful ? 3000 : 1500;
             messages.push({
               role: "assistant",
@@ -179,13 +166,20 @@ function extractWorkItems(assistantMessages: string[]): string[] {
   return workItems.slice(0, 10);
 }
 
+/**
+ * SessionEnd hook — structured for resilience against cancellation.
+ *
+ * Priority order (most critical first):
+ *   1. Local summary (instant, zero risk — survives any cancellation)
+ *   2. Parallel: cooldown animation + API uploads (critical data first)
+ *   3. Session end marker (nice-to-have metadata)
+ */
 export async function handleSessionEnd(): Promise<void> {
   const config = loadConfig();
   if (!config) {
     process.exit(0);
   }
 
-  // Early exit if plugin is disabled
   if (!isPluginEnabled()) {
     process.exit(0);
   }
@@ -204,80 +198,74 @@ export async function handleSessionEnd(): Promise<void> {
   const reason = hookInput.reason || "unknown";
   const transcriptPath = hookInput.transcript_path;
   const instanceId = hookInput.session_id || getInstanceIdForCwd(cwd);
+  const sessionName = getSessionName(cwd, instanceId || undefined);
 
-  // Set log context
-  setLogContext(cwd, getSessionName(cwd, instanceId || undefined));
-
-  // Play cooldown animation
-  await playCooldown("saving memory");
-
+  setLogContext(cwd, sessionName);
   logHook("session-end", `Session ending`, { reason });
 
+  // =========================================================
+  // Phase 1: LOCAL WORK (instant, survives any cancellation)
+  // =========================================================
+  const transcriptMessages = transcriptPath ? parseTranscript(transcriptPath) : [];
+  const allAssistant = transcriptMessages.filter((msg) => msg.role === "assistant");
+  const meaningful = allAssistant.filter((msg) => msg.isMeaningful);
+  const other = allAssistant.filter((msg) => !msg.isMeaningful);
+  const assistantMessages = [
+    ...meaningful.slice(-25),
+    ...other.slice(-15),
+  ].slice(-40);
+
+  // Save local summary FIRST — even if the hook gets killed after this,
+  // the next session-start will have context about what happened.
+  const workItems = extractWorkItems(assistantMessages.map((m) => m.content));
+  const existingContext = loadClaudeLocalContext();
+  let recentActivity = "";
+  if (existingContext) {
+    const activityMatch = existingContext.match(/## Recent Activity\n([\s\S]*)/);
+    if (activityMatch) {
+      recentActivity = activityMatch[1];
+    }
+  }
+  const newSummary = generateClaudeSummary(
+    sessionName,
+    workItems,
+    assistantMessages.map((m) => m.content)
+  );
+  saveClaudeLocalContext(newSummary + recentActivity);
+
+  // =========================================================
+  // Phase 2: PARALLEL API UPLOADS + ANIMATION
+  // Cooldown animation runs concurrently with network I/O
+  // so we don't waste budget on cosmetics before critical work.
+  // =========================================================
   try {
     const honcho = new Honcho(getHonchoClientOptions(config));
-    const sessionName = getSessionName(cwd, instanceId || undefined);
 
-    // Get session and peers using new fluent API
-    const session = await honcho.session(sessionName);
-    const userPeer = await honcho.peer(config.peerName);
-    const aiPeer = await honcho.peer(config.aiPeer);
+    const [session, userPeer, aiPeer] = await Promise.all([
+      honcho.session(sessionName),
+      honcho.peer(config.peerName),
+      honcho.peer(config.aiPeer),
+    ]);
 
-    // Parse transcript
-    const transcriptMessages = transcriptPath ? parseTranscript(transcriptPath) : [];
+    // Build all upload batches before sending
+    const queuedMessages = getQueuedMessages(cwd);
+    logHook("session-end", `Processing ${queuedMessages.length} queued + ${assistantMessages.length} assistant msgs`);
 
-    // =====================================================
-    // Step 1: Upload queued user messages (backup for failed fire-and-forget)
-    // Only upload messages for THIS session (by cwd), not other sessions
-    // =====================================================
-    const queuedMessages = getQueuedMessages(cwd);  // Filter by current session's cwd
-    logHook("session-end", `Processing ${queuedMessages.length} queued messages`);
-    if (queuedMessages.length > 0) {
-      // Chunk oversized messages instead of dropping them
-      const userMessages = queuedMessages.flatMap((msg) => {
-        const chunks = chunkContent(msg.content);
-        return chunks.map(chunk =>
-          userPeer.message(chunk, {
-            createdAt: msg.timestamp,
-            metadata: {
-              instance_id: msg.instanceId || undefined,
-              session_affinity: sessionName,
-            },
-          })
-        );
-      });
-      if (userMessages.length > 0) {
-        logApiCall("session.addMessages", "POST", `${queuedMessages.length} queued user messages (${userMessages.length} after chunking)`);
-        await session.addMessages(userMessages);
-      }
-      markMessagesUploaded(cwd);  // Only clear this session's messages
-    }
+    const userMessages = queuedMessages.flatMap((msg) => {
+      const chunks = chunkContent(msg.content);
+      return chunks.map(chunk =>
+        userPeer.message(chunk, {
+          createdAt: msg.timestamp,
+          metadata: {
+            instance_id: msg.instanceId || undefined,
+            session_affinity: sessionName,
+          },
+        })
+      );
+    });
 
-    // =====================================================
-    // Step 2: Save assistant messages that weren't captured by post-tool-use
-    // post-tool-use only logs tool activity, not Claude's prose responses
-    // This captures: explanations, summaries, recommendations, analysis
-    // =====================================================
-    let assistantMessages: Array<{ role: string; content: string; isMeaningful?: boolean; timestamp?: string }> = [];
-    if (config.saveMessages !== false && transcriptMessages.length > 0) {
-      // Extract assistant prose - prioritize meaningful content
-      const allAssistant = transcriptMessages.filter((msg) => msg.role === "assistant");
-
-      // Prioritize meaningful messages (explanations, summaries, etc.)
-      const meaningful = allAssistant.filter((msg) => msg.isMeaningful);
-      const other = allAssistant.filter((msg) => !msg.isMeaningful);
-
-      // Take all meaningful + recent others, up to 40 total
-      assistantMessages = [
-        ...meaningful.slice(-25),  // Keep more meaningful content
-        ...other.slice(-15),       // Keep some context
-      ].slice(-40);
-
-      // Upload assistant messages for claude peer knowledge extraction
-      // This is the KEY fix: capturing actual reasoning, not just tool calls
-      if (assistantMessages.length > 0) {
-        const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
-
-        const messagesToSend = assistantMessages.flatMap((msg) => {
+    const aiMessages = (config.saveMessages !== false && assistantMessages.length > 0)
+      ? assistantMessages.flatMap((msg) => {
           const chunks = chunkContent(msg.content);
           return chunks.map(chunk =>
             aiPeer.message(chunk, {
@@ -290,59 +278,83 @@ export async function handleSessionEnd(): Promise<void> {
               },
             })
           );
-        });
+        })
+      : [];
 
-        logApiCall("session.addMessages", "POST", `${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful, ${messagesToSend.length} after chunking)`);
-        await session.addMessages(messagesToSend);
+    const endMarker = aiPeer.message(
+      `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
+      {
+        createdAt: new Date().toISOString(),
+        metadata: {
+          instance_id: instanceId || undefined,
+          session_affinity: sessionName,
+        },
       }
-    }
-
-    // =====================================================
-    // Step 3: Generate and save claude self-summary
-    // =====================================================
-    const workItems = extractWorkItems(assistantMessages.map((m) => m.content));
-    const existingContext = loadClaudeLocalContext();
-
-    // Preserve recent activity from existing context
-    let recentActivity = "";
-    if (existingContext) {
-      const activityMatch = existingContext.match(/## Recent Activity\n([\s\S]*)/);
-      if (activityMatch) {
-        recentActivity = activityMatch[1];
-      }
-    }
-
-    const newSummary = generateClaudeSummary(
-      sessionName,
-      workItems,
-      assistantMessages.map((m) => m.content)
     );
 
-    // Append preserved activity
-    saveClaudeLocalContext(newSummary + recentActivity);
+    // Single addMessages call with everything — one round trip instead of three.
+    const allMessages = [...userMessages, ...aiMessages, endMarker];
 
-    // =====================================================
-    // Step 4: Log session end marker
-    // =====================================================
-    await session.addMessages([
-      aiPeer.message(
-        `[Session ended] Reason: ${reason}, Messages: ${transcriptMessages.length}, Time: ${new Date().toISOString()}`,
-        {
-          createdAt: new Date().toISOString(),
-          metadata: {
-            instance_id: instanceId || undefined,
-            session_affinity: sessionName,
-          },
+    if (allMessages.length > 0) {
+      const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
+      logApiCall("session.addMessages", "POST",
+        `${userMessages.length} user + ${aiMessages.length} assistant (${meaningfulCount} meaningful) + 1 marker`);
+
+      // Start API upload immediately; run animation concurrently.
+      const uploadPromise = session.addMessages(allMessages);
+
+      // Trap SIGTERM/SIGINT to prevent default termination while upload
+      // is in flight. The handler is a no-op — its only purpose is to
+      // keep the process alive. Cooldown's own exit handler cleans up
+      // the cursor if the process exits unexpectedly.
+      const sigHandler = () => {};
+      process.on("SIGINT", sigHandler);
+      if (process.platform === "win32") {
+        process.on("SIGBREAK", sigHandler);
+      } else {
+        process.on("SIGTERM", sigHandler);
+      }
+
+      const removeSigHandlers = () => {
+        process.removeListener("SIGINT", sigHandler);
+        if (process.platform === "win32") {
+          process.removeListener("SIGBREAK", sigHandler);
+        } else {
+          process.removeListener("SIGTERM", sigHandler);
         }
-      ),
-    ]);
+      };
+
+      // Hard safety net: if the upload hangs beyond SDK timeout + margin,
+      // force exit. Local summary was already saved in phase 1.
+      const hardTimeout = setTimeout(() => {
+        logHook("session-end", "Hard timeout reached — forcing exit");
+        removeSigHandlers();
+        process.exit(0);
+      }, 12_000);
+      hardTimeout.unref();
+
+      let uploadSucceeded = false;
+      await Promise.all([
+        uploadPromise.then(() => { uploadSucceeded = true; }).finally(() => {
+          clearTimeout(hardTimeout);
+          removeSigHandlers();
+        }),
+        playCooldown("saving memory"),
+      ]);
+
+      if (uploadSucceeded && queuedMessages.length > 0) {
+        markMessagesUploaded(cwd);
+      }
+    } else {
+      await playCooldown("saving memory");
+    }
 
     const meaningfulCount = assistantMessages.filter(m => m.isMeaningful).length;
     logHook("session-end", `Session saved: ${assistantMessages.length} assistant msgs (${meaningfulCount} meaningful), ${queuedMessages.length} queued msgs`);
     process.exit(0);
   } catch (error) {
     logHook("session-end", `Error: ${error}`, { error: String(error) });
-    console.error(`[honcho] Warning: ${error}`);
-    process.exit(1);
+    // Local summary was already saved in phase 1 — not a total loss.
+    process.exit(0);
   }
 }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -106,12 +106,11 @@ export async function handleSessionStart(): Promise<void> {
     // Also stores instanceId per-cwd to prevent cross-session collision
     setCachedSessionId(cwd, sessionName, session.id, claudeInstanceId);
 
-    // Step 4: Set session peer configuration (fire-and-forget)
-    // New SDK uses session.setPeerConfiguration()
-    Promise.all([
-      session.setPeerConfiguration(userPeer, { observeMe: true, observeOthers: false }),
-      session.setPeerConfiguration(aiPeer, { observeMe: false, observeOthers: true }),
-    ]).catch((e) => logHook("session-start", `Set peers failed: ${e}`));
+    // Step 4: Add peers with observation config (materializes session server-side)
+    await session.addPeers([
+      [userPeer, { observeMe: true, observeOthers: false }],
+      [aiPeer, { observeMe: true, observeOthers: true }],
+    ]);
 
     // Only persist session names for per-directory strategy (stable names).
     // Dynamic strategies (git-branch, chat-instance) change per session,

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,10 +1,9 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getLinkedWorkspaces, getHonchoBaseUrl } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import {
   setCachedUserContext,
   setCachedClaudeContext,
   setCachedSessionId,
-  loadClaudeLocalContext,
   resetMessageCount,
   setClaudeInstanceId,
   getCachedGitState,
@@ -12,7 +11,6 @@ import {
   detectGitChanges,
 } from "../cache.js";
 import { Spinner } from "../spinner.js";
-import { displayHonchoStartup } from "../pixel.js";
 import { captureGitState, getRecentCommits, isGitRepo, inferFeatureContext } from "../git.js";
 import { logHook, logApiCall, logCache, logFlow, logAsync, setLogContext } from "../log.js";
 import { verboseApiResult, verboseList, clearVerboseLog } from "../visual.js";
@@ -24,13 +22,6 @@ interface HookInput {
   cwd?: string;
   source?: string;
   workspace_roots?: string[];
-}
-
-function formatRepresentation(rep: any): string {
-  if (typeof rep === "string" && rep.trim()) {
-    return rep;
-  }
-  return "";
 }
 
 export async function handleSessionStart(): Promise<void> {
@@ -88,16 +79,9 @@ export async function handleSessionStart(): Promise<void> {
     setCachedGitState(cwd, currentGitState);
   }
 
-  // Show workspace info immediately (before any API calls)
-  console.log(displayHonchoStartup(
-    "Honcho Memory",
-    `${config.workspace} · ${sessionName}`,
-    currentGitState?.branch ? `branch: ${currentGitState.branch}` : undefined,
-  ));
-
-  // Start loading animation with neural style
+  // Start loading animation with session name visible in the spinner message
   const spinner = new Spinner({ style: "neural" });
-  spinner.start("loading memory");
+  spinner.start(`${sessionName} · loading memory`);
 
   try {
     logHook("session-start", `Starting session in ${cwd}`, { branch: currentGitState?.branch });
@@ -107,8 +91,7 @@ export async function handleSessionStart(): Promise<void> {
     const honcho = new Honcho(getHonchoClientOptions(config));
 
     // Step 1-3: Get session and peers using new fluent API (lazily created)
-    spinner.update("Loading session");
-    const sessionName = getSessionName(cwd, claudeInstanceId);
+    spinner.update(`${sessionName} · loading session`);
 
     const startTime = Date.now();
     // New SDK: session() and peer() are async and create lazily
@@ -161,119 +144,54 @@ export async function handleSessionStart(): Promise<void> {
       }
     }
 
-    // Step 5: PARALLEL fetch all context (the big optimization!)
-    spinner.update("Fetching memory context");
-    logAsync("context-fetch", "Starting 5 parallel context fetches");
-    const contextParts: string[] = [];
+    // Step 5: Warm caches + trigger dialectic reasoning.
+    // context() results are cached for user-prompt hook (sole injection point).
+    // chat() triggers Honcho's dialectic engine — the results aren't displayed
+    // but the reasoning feeds back into the knowledge graph.
+    spinner.update(`${sessionName} · fetching context`);
 
-    // Header with git context
-    let headerContent = `## Honcho Memory System Active
-- User: ${config.peerName}
-- AI: ${config.aiPeer}
-- Workspace: ${config.workspace}
-- Session: ${sessionName}
-- Directory: ${cwd}`;
-
-    if (currentGitState) {
-      headerContent += `\n- Git Branch: ${currentGitState.branch}`;
-      headerContent += `\n- Git HEAD: ${currentGitState.commit}`;
-      if (currentGitState.isDirty) {
-        headerContent += `\n- Working Tree: ${currentGitState.dirtyFiles.length} uncommitted changes`;
-      }
-    }
-
-    // Add inferred feature context to header
-    if (featureContext && featureContext.confidence !== "low") {
-      headerContent += `\n- Feature: ${featureContext.type} - ${featureContext.description}`;
-      if (featureContext.areas.length > 0) {
-        headerContent += `\n- Areas: ${featureContext.areas.join(", ")}`;
-      }
-    }
-
-    contextParts.push(headerContent);
-
-    // Add inferred feature context section
-    if (featureContext) {
-      const featureSection = [
-        `## Inferred Feature Context`,
-        `- Type: ${featureContext.type}`,
-        `- Description: ${featureContext.description}`,
-      ];
-      if (featureContext.keywords.length > 0) {
-        featureSection.push(`- Keywords: ${featureContext.keywords.join(", ")}`);
-      }
-      if (featureContext.areas.length > 0) {
-        featureSection.push(`- Code Areas: ${featureContext.areas.join(", ")}`);
-      }
-      featureSection.push(`- Confidence: ${featureContext.confidence}`);
-      contextParts.push(featureSection.join("\n"));
-    }
-
-    // Add git changes section if external changes detected
-    if (gitChanges.length > 0) {
-      const changeDescriptions = gitChanges.map((c) => `- ${c.description}`).join("\n");
-      contextParts.push(`## Git Activity Since Last Session\n${changeDescriptions}`);
-    }
-
-    // Load local claude context immediately (instant, no API call)
-    const localClaudeContext = loadClaudeLocalContext();
-    if (localClaudeContext) {
-      contextParts.push(`## Local Context (What I Was Working On)\n${localClaudeContext.slice(0, 2000)}`);
-    }
-
-    // Build context-aware dialectic queries
-    const branchContext = currentGitState ? ` They are currently on git branch '${currentGitState.branch}'.` : "";
-    const changeContext = gitChanges.length > 0 && gitChanges[0].type === "branch_switch"
-      ? ` Note: they just switched branches from '${gitChanges[0].from}' to '${gitChanges[0].to}'.`
-      : "";
+    const branchContext = currentGitState ? ` on branch '${currentGitState.branch}'` : "";
     const featureHint = featureContext && featureContext.confidence !== "low"
-      ? ` Current work appears to be: ${featureContext.type} - ${featureContext.description}.`
+      ? ` Working on: ${featureContext.type} - ${featureContext.description}.`
       : "";
 
-    // Parallel API calls for rich context
+    logAsync("context-fetch", "Starting 2 parallel context fetches + 2 dialectic fire-and-forget");
+
     const fetchStart = Date.now();
-    const [userContextResult, claudeContextResult, summariesResult, userChatResult, claudeChatResult] =
+    const [userContextResult, claudeContextResult] =
       await Promise.allSettled([
-        // 1. Get user's context (SESSION-SCOPED for relevance)
         userPeer.context({
           maxConclusions: 25,
           includeMostFrequent: true,
         }),
-        // 2. Get claude's context (self-awareness, also session-scoped)
         aiPeer.context({
           maxConclusions: 15,
           includeMostFrequent: true,
         }),
-        // 3. Get session summaries
-        session.summaries(),
-        // 4. Dialectic: Ask about user (context-enhanced)
-        userPeer.chat(
-          `Summarize what you know about ${config.peerName} in 2-3 sentences. Focus on their preferences, current projects, and working style.${branchContext}${changeContext}${featureHint}`,
-          { session }
-        ),
-        // 5. Dialectic: Ask about claude (self-reflection, context-enhanced)
-        aiPeer.chat(
-          `What has ${config.aiPeer} been working on recently?${branchContext}${featureHint} Summarize the AI assistant's recent activities and focus areas relevant to the current work context.`,
-          { session }
-        ),
       ]);
 
-    // Log async results
+    // Dialectic: fire-and-forget. Results feed the knowledge graph;
+    // we don't need them for cache or display.
+    const dialecticLevel = config.reasoningLevel ?? "low";
+    userPeer.chat(
+      `Summarize what you know about ${config.peerName}. Focus on preferences, current projects, and working style.${branchContext}${featureHint}`,
+      { session, reasoningLevel: dialecticLevel }
+    ).catch((e) => logHook("session-start", `Dialectic (user) failed: ${e}`));
+
+    aiPeer.chat(
+      `What has ${config.aiPeer} been working on recently?${branchContext}${featureHint} Summarize recent activities relevant to the current work.`,
+      { session, reasoningLevel: dialecticLevel }
+    ).catch((e) => logHook("session-start", `Dialectic (ai) failed: ${e}`));
+
     const fetchDuration = Date.now() - fetchStart;
     const asyncResults = [
       { name: "peer.context(user)", success: userContextResult.status === "fulfilled" },
       { name: "peer.context(claude)", success: claudeContextResult.status === "fulfilled" },
-      { name: "session.summaries", success: summariesResult.status === "fulfilled" },
-      { name: "peer.chat(user)", success: userChatResult.status === "fulfilled" },
-      { name: "peer.chat(claude)", success: claudeChatResult.status === "fulfilled" },
     ];
     const successCount = asyncResults.filter(r => r.success).length;
-    logAsync("context-fetch", `Completed: ${successCount}/5 succeeded in ${fetchDuration}ms`, asyncResults);
+    logAsync("context-fetch", `Context: ${successCount}/2 succeeded in ${fetchDuration}ms (dialectic fire-and-forget)`, asyncResults);
 
-    // ========== VERBOSE OUTPUT (file-based) ==========
-    // Written to ~/.honcho/verbose.log — NOT shown in Ctrl+O.
-    // SessionStart stdout is always visible to Claude, so we can't
-    // use stdout for debug data. View with: tail -f ~/.honcho/verbose.log
+    // Verbose output (file-based — ~/.honcho/verbose.log)
     if (userContextResult.status === "fulfilled" && userContextResult.value) {
       const ctx = userContextResult.value as any;
       verboseApiResult("peer.context(user) → representation", ctx.representation);
@@ -283,146 +201,32 @@ export async function handleSessionStart(): Promise<void> {
       const ctx = claudeContextResult.value as any;
       verboseApiResult("peer.context(claude) → representation", ctx.representation);
     }
-    if (summariesResult.status === "fulfilled" && summariesResult.value) {
-      const s = summariesResult.value as any;
-      const short = s.shortSummary;
-      verboseApiResult("session.summaries() → shortSummary", short?.content);
-    }
-    if (userChatResult.status === "fulfilled") {
-      const chatVal = typeof userChatResult.value === "string" ? userChatResult.value : (userChatResult.value as any)?.content;
-      verboseApiResult(`peer.chat(user) → "${config.peerName}"`, chatVal);
-    }
-    if (claudeChatResult.status === "fulfilled") {
-      const chatVal = typeof claudeChatResult.value === "string" ? claudeChatResult.value : (claudeChatResult.value as any)?.content;
-      verboseApiResult(`peer.chat(claude) → "${config.aiPeer}"`, chatVal);
-    }
 
-    // ========== CONSOLIDATED CONTEXT OUTPUT ==========
-    // Reduced from 6+ overlapping sections to 2-3 focused sections
-    // (as recommended in FEEDBACK-FROM-CLAUDE.md)
-
-    // Section 1: User Profile + Conclusions (CONSOLIDATED)
-    // Combines: peerCard and representation
-    // Skips redundant "AI Summary" dialectic if we have good conclusions
+    // Cache results for user-prompt hook
     if (userContextResult.status === "fulfilled" && userContextResult.value) {
       const context = userContextResult.value as any;
-      setCachedUserContext(context); // Cache for user-prompt hook
+      setCachedUserContext(context);
       const rep = context.representation;
-      const repConclusionCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      logCache("write", "userContext", `${repConclusionCount} conclusions`);
-
-      const userSection: string[] = [];
-
-      const peerCard = context.peerCard;
-      if (peerCard && peerCard.length > 0) {
-        userSection.push(peerCard.join("\n"));
-      }
-
-      // Add conclusions (session-scoped, so should be relevant)
-      if (rep) {
-        const repText = formatRepresentation(rep);
-        if (repText) {
-          userSection.push(repText);
-        }
-      }
-
-      if (userSection.length > 0) {
-        contextParts.push(`## ${config.peerName}'s Profile\n${userSection.join("\n\n")}`);
-      }
+      const count = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
+      logCache("write", "userContext", `${count} conclusions`);
     }
 
-    // Section 2: Recent Work (CONSOLIDATED)
-    // Combines: claude conclusions, session summary, self-reflection
-    // Prioritizes concrete work items over vague summaries
     if (claudeContextResult.status === "fulfilled" && claudeContextResult.value) {
       const context = claudeContextResult.value as any;
-      setCachedClaudeContext(context); // Cache
+      setCachedClaudeContext(context);
       const rep = context.representation;
-      const claudeRepConclusionCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      logCache("write", "claudeContext", `${claudeRepConclusionCount} conclusions`);
-
-      if (rep) {
-        const repText = formatRepresentation(rep);
-        if (repText) {
-          contextParts.push(`## ${config.aiPeer}'s Work History (Self-Context)\n${repText}`);
-        }
-      }
+      const count = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
+      logCache("write", "claudeContext", `${count} conclusions`);
     }
 
-    // Session summary - only include SHORT summary (skip Extended History to reduce noise)
-    if (summariesResult.status === "fulfilled" && summariesResult.value) {
-      const s = summariesResult.value as any;
-      const shortSummary = s.shortSummary;
-      if (shortSummary?.content) {
-        contextParts.push(`## Recent Session Summary\n${shortSummary.content}`);
-      }
-      // Skip long_summary - it overlaps with conclusions and adds too many tokens
-    }
-
-    // AI dialectic summaries - always include when available
-    // Chat result may be a string or {content: string}
-    const userChatContent = userChatResult.status === "fulfilled"
-      ? (typeof userChatResult.value === "string" ? userChatResult.value : (userChatResult.value as any)?.content)
-      : null;
-    if (userChatContent) {
-      contextParts.push(`## AI Summary of ${config.peerName}\n${userChatContent}`);
-    }
-
-    const claudeChatContent = claudeChatResult.status === "fulfilled"
-      ? (typeof claudeChatResult.value === "string" ? claudeChatResult.value : (claudeChatResult.value as any)?.content)
-      : null;
-    if (claudeChatContent) {
-      contextParts.push(`## AI Self-Reflection (What ${config.aiPeer} Has Been Doing)\n${claudeChatContent}`);
-    }
-
-    // Fetch context from linked workspaces (reads only, writes stay local)
-    const linkedWorkspaces = getLinkedWorkspaces();
-    if (linkedWorkspaces.length > 0) {
-      spinner.update("Fetching linked context");
-      logAsync("linked-context", `Fetching from ${linkedWorkspaces.length} linked workspace(s): ${linkedWorkspaces.join(", ")}`);
-
-      const linkedResults = await Promise.allSettled(
-        linkedWorkspaces.map(async (ws) => {
-          const linkedClient = new Honcho({
-            apiKey: config.apiKey,
-            baseURL: getHonchoBaseUrl(config),
-            workspaceId: ws,
-          });
-          const linkedPeer = await linkedClient.peer(config.peerName);
-          return { ws, context: await linkedPeer.context({ maxConclusions: 10, includeMostFrequent: true }) };
-        })
-      );
-
-      for (const result of linkedResults) {
-        if (result.status === "fulfilled" && result.value.context) {
-          const { ws, context } = result.value;
-          const rep = formatRepresentation((context as any).representation);
-          if (rep) {
-            contextParts.push(`## Linked Context (${ws})\n${rep}`);
-          }
-          logAsync("linked-context", `${ws}: loaded`);
-        } else if (result.status === "rejected") {
-          logAsync("linked-context", `Failed: ${result.reason}`);
-        }
-      }
-    }
-
-    // Stop spinner
+    // Stop spinner; avoid stdout writes here to prevent UI artifacts.
     spinner.stop();
 
-    logFlow("complete", `Memory loaded: ${contextParts.length} sections, ${successCount}/5 API calls succeeded`);
-
-    // Output all context
-    console.log(`\n[${config.aiPeer}/Honcho Memory Loaded]\n\n${contextParts.join("\n\n")}`);
+    logFlow("complete", `Cache warmed: ${successCount}/2 context + 2 dialectic (fire-and-forget)`);
     process.exit(0);
   } catch (error) {
     logHook("session-start", `Error: ${error}`, { error: String(error) });
     spinner.stop();
-    // Degrade gracefully — workspace info was already shown above.
-    // Output whatever context we managed to collect.
-    if (contextParts.length > 0) {
-      console.log(`\n[${config.aiPeer}/Honcho Memory (partial)]\n\n${contextParts.join("\n\n")}`);
-    }
     process.exit(0);
   }
 }

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,18 +1,20 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getLinkedWorkspaces, getHonchoBaseUrl } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
   isContextCacheStale,
   setCachedUserContext,
+  getMessageCount,
   incrementMessageCount,
   shouldRefreshKnowledgeGraph,
   markKnowledgeGraphRefreshed,
   getInstanceIdForCwd,
-  chunkContent,
+  queueMessage,
 } from "../cache.js";
 import { logHook, logApiCall, logCache, setLogContext } from "../log.js";
 import { visContextLine, visSkipMessage, addSystemMessage, verboseApiResult, verboseList } from "../visual.js";
+import { honchoSessionUrl } from "../styles.js";
 
 interface HookInput {
   prompt?: string;
@@ -21,59 +23,72 @@ interface HookInput {
   workspace_roots?: string[];
 }
 
-// Patterns to skip heavy context retrieval
+// Patterns to skip context injection
 const SKIP_CONTEXT_PATTERNS = [
   /^(yes|no|ok|sure|thanks|y|n|yep|nope|yeah|nah|continue|go ahead|do it|proceed)$/i,
   /^\//, // slash commands
 ];
 
+const FETCH_TIMEOUT_MS = 4000;
+
 /**
- * Extract meaningful topics from a prompt for semantic search
- * Instead of crude truncation (prompt.slice(0,500)), extract entities and terms
+ * Extract meaningful topics from a prompt for semantic search.
+ * Returns terms that are high-signal for conclusion matching.
  */
 function extractTopics(prompt: string): string[] {
   const topics: string[] = [];
 
-  // Extract file paths (high signal)
+  // File paths (high signal)
   const filePaths = prompt.match(/[\w\-\/\.]+\.(ts|tsx|js|jsx|py|rs|go|md|json|yaml|yml|toml|sql)/gi) || [];
   topics.push(...filePaths.slice(0, 5));
 
-  // Extract quoted strings (explicit references)
+  // Quoted strings (explicit references)
   const quoted = prompt.match(/"([^"]+)"/g)?.map(q => q.slice(1, -1)) || [];
   topics.push(...quoted.slice(0, 3));
 
-  // Extract technical terms (common frameworks/tools)
-  const techTerms = prompt.match(/\b(react|vue|svelte|angular|elysia|express|fastapi|django|flask|postgres|redis|docker|kubernetes|bun|node|deno|typescript|python|rust|go|graphql|rest|api|auth|oauth|jwt|stripe|webhook)\b/gi) || [];
+  // Technical terms
+  const techTerms = prompt.match(/\b(react|vue|svelte|angular|elysia|express|fastapi|django|flask|postgres|redis|docker|kubernetes|bun|node|deno|typescript|python|rust|go|graphql|rest|api|auth|oauth|jwt|stripe|webhook|honcho|mcp|claude|cursor|sentry)\b/gi) || [];
   topics.push(...[...new Set(techTerms.map(t => t.toLowerCase()))].slice(0, 5));
 
-  // Extract error patterns (debugging context)
+  // Error patterns
   const errors = prompt.match(/error[:\s]+[\w\s]+|failed[:\s]+[\w\s]+|exception[:\s]+[\w\s]+/gi) || [];
   topics.push(...errors.slice(0, 2));
 
-  // If we found meaningful topics, use them; otherwise fall back to first 200 chars
   if (topics.length > 0) {
     return [...new Set(topics)];
   }
 
-  // Fallback: extract meaningful words (>3 chars, not common words)
-  const commonWords = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'are', 'was', 'were', 'been', 'being', 'has', 'had', 'does', 'did', 'will', 'would', 'could', 'should', 'can', 'may', 'might', 'must', 'shall', 'need', 'want', 'like', 'just', 'also', 'more', 'some', 'what', 'when', 'where', 'which', 'who', 'how', 'why', 'all', 'each', 'every', 'both', 'few', 'most', 'other', 'into', 'over', 'such', 'only', 'same', 'than', 'very', 'your', 'make', 'take', 'come', 'give', 'look', 'think', 'know', 'see', 'time', 'year', 'people', 'way', 'day', 'man', 'woman', 'child', 'world', 'life', 'hand', 'part', 'place', 'case', 'week', 'company', 'system', 'program', 'question', 'work', 'government', 'number', 'night', 'point', 'home', 'water', 'room', 'mother', 'area', 'money', 'story', 'fact', 'month', 'lot', 'right', 'study', 'book', 'eye', 'job', 'word', 'business', 'issue', 'side', 'kind', 'head', 'house', 'service', 'friend', 'father', 'power', 'hour', 'game', 'line', 'end', 'member', 'law', 'car', 'city', 'community', 'name']);
+  // Fallback: meaningful words >3 chars minus stopwords
+  const stopwords = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'are', 'was', 'were', 'been', 'being', 'has', 'had', 'does', 'did', 'will', 'would', 'could', 'should', 'can', 'may', 'might', 'must', 'shall', 'need', 'want', 'like', 'just', 'also', 'more', 'some', 'what', 'when', 'where', 'which', 'who', 'how', 'why', 'all', 'each', 'every', 'both', 'few', 'most', 'other', 'into', 'over', 'such', 'only', 'same', 'than', 'very', 'your', 'make', 'take', 'come', 'give', 'look', 'think', 'know']);
   const words = prompt.toLowerCase().match(/\b[a-z]{4,}\b/g) || [];
-  const meaningfulWords = words.filter(w => !commonWords.has(w));
-  return [...new Set(meaningfulWords)].slice(0, 10);
+  return [...new Set(words.filter(w => !stopwords.has(w)))].slice(0, 10);
 }
 
 function shouldSkipContextRetrieval(prompt: string): boolean {
   return SKIP_CONTEXT_PATTERNS.some((p) => p.test(prompt.trim()));
 }
 
+function formatSessionLink(sessionUrl: string): string {
+  return `view your session in honcho GUI: ${sessionUrl}`;
+}
 
+/**
+ * UserPromptSubmit hook — serves cached context instantly, refreshes when stale.
+ *
+ * Context lifecycle:
+ *   SessionStart  -> warms cache (parallel API calls, 30s budget)
+ *   UserPrompt    -> serves cache; refreshes (with 4s timeout) when TTL expires or message threshold hit
+ *   PreCompact    -> re-warms cache before context window reset
+ *
+ * On refresh failure, silently falls back to stale cache.
+ * On no cache at all, exits silently — context will arrive next turn.
+ */
 export async function handleUserPrompt(): Promise<void> {
   const config = loadConfig();
   if (!config) {
     process.exit(0);
   }
 
-  // Early exit if plugin is disabled
   if (!isPluginEnabled()) {
     process.exit(0);
   }
@@ -91,146 +106,155 @@ export async function handleUserPrompt(): Promise<void> {
   const prompt = hookInput.prompt || "";
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();
   const instanceId = hookInput.session_id || getInstanceIdForCwd(cwd);
+  const sessionName = getSessionName(cwd, instanceId || undefined);
 
-  // Set log context for this hook
-  setLogContext(cwd, getSessionName(cwd, instanceId || undefined));
+  setLogContext(cwd, sessionName);
 
-  // Skip empty prompts
   if (!prompt.trim()) {
     process.exit(0);
   }
 
   logHook("user-prompt", `Prompt received (${prompt.length} chars)`);
 
-  // Start upload immediately (we'll await before exit)
-  let uploadPromise: Promise<void> | null = null;
+  // Queue user prompt for upload at session-end (instant, no network)
   if (config.saveMessages !== false) {
-    uploadPromise = uploadMessageAsync(config, cwd, prompt, instanceId || undefined);
+    queueMessage(prompt, config.peerName, cwd, instanceId || undefined);
   }
 
-  // Track message count for threshold-based knowledge graph refresh
-  const messageCount = incrementMessageCount();
+  // Track message count for threshold-based refresh
+  const messageCountBefore = getMessageCount();
+  incrementMessageCount();
+  const shouldShowSessionLink = messageCountBefore === 0;
 
-  // For trivial prompts, skip heavy context retrieval but still upload
+  // Build session link lazily — only materialized on first message
+  const sessionLink = shouldShowSessionLink
+    ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+    : undefined;
+
+  // Skip trivial prompts — no context needed for "y", "ok", etc.
   if (shouldSkipContextRetrieval(prompt)) {
     logHook("user-prompt", "Skipping context (trivial prompt)");
-    visSkipMessage("user-prompt", "trivial prompt");
-    if (uploadPromise) await uploadPromise.catch((e) => logHook("user-prompt", `Upload failed: ${e}`, { error: String(e) }));
+    visSkipMessage("user-prompt", sessionLink ? `${sessionLink} · trivial prompt` : "trivial prompt");
     process.exit(0);
   }
 
-  // Determine if we should refresh: either cache is stale OR message threshold reached
+  // Decide whether to refresh: TTL expired or message threshold hit
   const forceRefresh = shouldRefreshKnowledgeGraph();
   const cachedContext = getCachedUserContext();
   const cacheIsStale = isContextCacheStale();
 
   if (cachedContext && !cacheIsStale && !forceRefresh) {
-    // Use cached context - instant response
-    logCache("hit", "userContext", "using cached");
+    // Fresh cache — serve instantly, no API call
+    logCache("hit", "userContext", "fresh cache");
+    verboseApiResult("peer.context() -> representation (cached)", cachedContext?.representation);
+    verboseList("peer.context() -> peerCard (cached)", cachedContext?.peerCard);
 
-    // Verbose output (file-based — ~/.honcho/verbose.log)
-    // UserPromptSubmit stdout is always visible to Claude, so we use
-    // the log file for debug data. View with: tail -f ~/.honcho/verbose.log
-    const cachedRep = cachedContext?.representation;
-    verboseApiResult("session.context() → representation (cached)", cachedRep);
-    verboseList("session.context() → peerCard (cached)", cachedContext?.peerCard);
-
-    const contextParts = formatCachedContext(cachedContext, config.peerName);
-    if (contextParts.length > 0) {
-      const rep = cachedContext?.representation;
-      const conclusionCount = typeof rep === "string" ? rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#")).length : 0;
-      const visMsg = visContextLine("user-prompt", {
-        conclusions: conclusionCount,
-        insights: 0,
-        cached: true,
-      }) || "[honcho] user-prompt \u2190 context injected (cached)";
-      outputContext(config.peerName, contextParts, visMsg);
-    } else {
-      outputSystemOnly("[honcho] user-prompt \u2022 no cached context available");
-    }
-    if (uploadPromise) await uploadPromise.catch((e) => logHook("user-prompt", `Upload failed: ${e}`, { error: String(e) }));
+    serveContext(config.peerName, cachedContext, true, sessionLink);
     process.exit(0);
   }
 
-  // Fetch fresh context when:
-  // 1. Cache is stale (TTL expired), OR
-  // 2. Message threshold reached (every N messages)
-  // Race against a 5s timeout -- serve stale cache on timeout instead of failing.
+  // Cache is stale or threshold reached — try a fresh fetch with timeout
   logCache("miss", "userContext", forceRefresh ? "threshold refresh" : "stale cache");
 
-  const FETCH_TIMEOUT_MS = 5000;
   const fetchResult = await Promise.race([
-    fetchFreshContext(config, cwd, prompt).then(r => ({ ok: true as const, ...r })),
+    fetchFreshContext(config, prompt).then(r => ({ ok: true as const, ...r })),
     new Promise<{ ok: false }>(resolve => setTimeout(() => resolve({ ok: false }), FETCH_TIMEOUT_MS)),
-  ]).catch((e): { ok: false } => {
-    logHook("user-prompt", `Context fetch failed: ${e}`, { error: String(e) });
-    return { ok: false };
-  });
+  ]).catch((): { ok: false } => ({ ok: false }));
 
   if (fetchResult.ok) {
-    const { parts: contextParts, conclusionCount } = fetchResult;
-    if (contextParts.length > 0) {
-      const visMsg = visContextLine("user-prompt", {
-        conclusions: conclusionCount,
-        insights: 0,
-        cached: false,
-      }) || "[honcho] user-prompt \u2190 fresh context injected";
-      outputContext(config.peerName, contextParts, visMsg);
-    } else {
-      outputSystemOnly("[honcho] user-prompt \u2022 no matching context found");
-    }
+    const { context } = fetchResult;
     if (forceRefresh) {
       markKnowledgeGraphRefreshed();
     }
-  } else {
-    // Timeout or error -- serve stale cache instead of showing nothing
-    const staleContext = getStaleCachedUserContext();
-    if (staleContext) {
-      logHook("user-prompt", "Serving stale cache after timeout/error");
-      const contextParts = formatCachedContext(staleContext, config.peerName);
-      if (contextParts.length > 0) {
-        const visMsg = "[honcho] user-prompt \u2190 context injected (stale)";
-        outputContext(config.peerName, contextParts, visMsg);
-      }
-    } else {
-      outputSystemOnly("[honcho] user-prompt \u2717 context unavailable");
+    if (context) {
+      serveContext(config.peerName, context, false, sessionLink);
+      process.exit(0);
     }
   }
 
-  // Ensure upload completes before exit
-  if (uploadPromise) await uploadPromise.catch((e) => logHook("user-prompt", `Upload failed: ${e}`, { error: String(e) }));
+  // Fetch failed or timed out — silently fall back to stale cache
+  const staleContext = getStaleCachedUserContext();
+  if (staleContext) {
+    logHook("user-prompt", "Serving stale cache after timeout");
+    serveContext(config.peerName, staleContext, true, sessionLink);
+  }
+  // No cache at all — exit silently, context will arrive after session-start completes
+
   process.exit(0);
 }
 
-async function uploadMessageAsync(config: any, cwd: string, prompt: string, instanceId?: string): Promise<void> {
-  logApiCall("session.addMessages", "POST", `user prompt (${prompt.length} chars)`);
-  const honcho = new Honcho(getHonchoClientOptions(config));
-  const sessionName = getSessionName(cwd, instanceId);
+/**
+ * Format and output context injection to Claude.
+ */
+function serveContext(
+  peerName: string,
+  context: any,
+  cached: boolean,
+  sessionLink?: string,
+): void {
+  const { parts: contextParts } = formatCachedContext(context, peerName);
+  if (contextParts.length === 0) return;
 
-  // Get session and peer using new fluent API
-  const session = await honcho.session(sessionName);
-  const userPeer = await honcho.peer(config.peerName);
-
-  // Chunk large messages to stay under API size limits
-  const chunks = chunkContent(prompt);
-  const messages = chunks.map(chunk =>
-    userPeer.message(chunk, {
-      metadata: {
-        instance_id: instanceId || undefined,
-        session_affinity: sessionName,
-      }
-    })
-  );
-  await session.addMessages(messages);
+  const visMsg = visContextLine("user-prompt", { cached });
+  outputContext(peerName, contextParts, sessionLink ? `${sessionLink}\n${visMsg}` : visMsg);
 }
 
-function formatCachedContext(context: any, peerName: string): string[] {
+async function fetchFreshContext(config: any, prompt: string): Promise<{ context: any }> {
+  const honcho = new Honcho(getHonchoClientOptions(config));
+  const userPeer = await honcho.peer(config.peerName);
+
+  const startTime = Date.now();
+
+  // Try search-based context first — returns conclusions relevant to the prompt
+  const topics = extractTopics(prompt);
+  const searchQuery = topics.length > 0 ? topics.join(" ") : undefined;
+
+  let contextResult: any = null;
+
+  if (searchQuery) {
+    try {
+      contextResult = await userPeer.context({
+        searchQuery,
+        searchTopK: 5,
+        searchMaxDistance: 0.7,
+        maxConclusions: 15,
+        includeMostFrequent: true,
+      });
+      logApiCall("peer.context", "GET", `search: ${searchQuery.slice(0, 60)}`, Date.now() - startTime, true);
+    } catch (e) {
+      // Search failed — fall through to static context
+      logHook("user-prompt", `Search context failed, falling back to static: ${e}`);
+    }
+  }
+
+  // Fallback: static context (no search query)
+  if (!contextResult) {
+    contextResult = await userPeer.context({
+      maxConclusions: 15,
+      includeMostFrequent: true,
+    });
+    logApiCall("peer.context", "GET", `static context`, Date.now() - startTime, true);
+  }
+
+  if (contextResult) {
+    setCachedUserContext(contextResult);
+    verboseApiResult("peer.context() -> representation (fresh)", (contextResult as any).representation);
+    verboseList("peer.context() -> peerCard (fresh)", (contextResult as any).peerCard);
+  }
+
+  return { context: contextResult };
+}
+
+function formatCachedContext(context: any, peerName: string): { parts: string[]; conclusionCount: number } {
   const parts: string[] = [];
+  let conclusionCount = 0;
   const rep = context?.representation;
 
   if (typeof rep === "string" && rep.trim()) {
     const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-    const summary = lines.slice(0, 5).map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
+    const selected = lines.slice(0, 5);
+    conclusionCount = selected.length;
+    const summary = selected.map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
     if (summary) parts.push(`Relevant conclusions: ${summary}`);
   }
 
@@ -239,104 +263,7 @@ function formatCachedContext(context: any, peerName: string): string[] {
     parts.push(`Profile: ${peerCard.join("; ")}`);
   }
 
-  return parts;
-}
-
-interface FreshContextResult {
-  parts: string[];
-  conclusionCount: number;
-}
-
-async function fetchFreshContext(config: any, cwd: string, prompt: string): Promise<FreshContextResult> {
-  const honcho = new Honcho(getHonchoClientOptions(config));
-  const sessionName = getSessionName(cwd);
-
-  // Get peer using new fluent API
-  const session = await honcho.session(sessionName);
-
-  const contextParts: string[] = [];
-  let conclusionCount = 0;
-
-  // Only use context() here - it's free and returns pre-computed knowledge
-  // Skip chat() - only use at session-start
-  const startTime = Date.now();
-
-  // Extract meaningful topics instead of crude truncation
-  const topics = extractTopics(prompt);
-  const searchQuery = topics.length > 0 ? topics.join(' ') : prompt.slice(0, 200);
-
-  const contextResult = await session.context({
-    searchQuery,
-    representationOptions: {
-      searchTopK: 5,
-      searchMaxDistance: 0.7,
-      maxConclusions: 10,
-    },
-  });
-
-  logApiCall("session.context", "GET", `search query`, Date.now() - startTime, true);
-
-  if (contextResult) {
-    setCachedUserContext(contextResult); // Update cache
-    const rep = (contextResult as any).representation;
-
-    // Verbose output (file-based — ~/.honcho/verbose.log)
-    // UserPromptSubmit stdout is always visible, so debug data goes to file.
-    verboseApiResult("session.context() → representation", rep);
-    verboseList("session.context() → peerCard", (contextResult as any).peerCard);
-
-    if (typeof rep === "string" && rep.trim()) {
-      const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-      conclusionCount = lines.length;
-      const summary = lines.slice(0, 5).map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
-      if (summary) contextParts.push(`Relevant conclusions: ${summary}`);
-      logCache("write", "userContext", `${conclusionCount} conclusions`);
-    }
-
-    const peerCard = (contextResult as any).peerCard;
-    if (peerCard?.length) {
-      contextParts.push(`Profile: ${peerCard.join("; ")}`);
-    }
-  }
-
-  // Fetch from linked workspaces (lightweight — just conclusions, no dialectic)
-  const linkedWorkspaces = getLinkedWorkspaces();
-  if (linkedWorkspaces.length > 0) {
-    const linkedResults = await Promise.allSettled(
-      linkedWorkspaces.map(async (ws) => {
-        const linkedClient = new Honcho({
-          apiKey: config.apiKey,
-          baseURL: getHonchoBaseUrl(config),
-          workspaceId: ws,
-        });
-        const linkedSession = await linkedClient.session(sessionName);
-        return {
-          ws,
-          context: await linkedSession.context({
-            searchQuery,
-            representationOptions: { searchTopK: 3, searchMaxDistance: 0.7, maxConclusions: 5 },
-          }),
-        };
-      })
-    );
-
-    for (const result of linkedResults) {
-      if (result.status === "fulfilled" && result.value.context) {
-        const rep = (result.value.context as any).representation;
-        if (typeof rep === "string" && rep.trim()) {
-          const lines = rep.split("\n").filter((l: string) => l.trim() && !l.startsWith("#"));
-          const summary = lines.slice(0, 3).map((l: string) => l.replace(/^\[.*?\]\s*/, "").replace(/^- /, "")).join("; ");
-          if (summary) contextParts.push(`Linked (${result.value.ws}): ${summary}`);
-        }
-      }
-    }
-  }
-
-  return { parts: contextParts, conclusionCount };
-}
-
-function outputSystemOnly(message: string): void {
-  console.log(JSON.stringify({ systemMessage: message }));
+  return { parts, conclusionCount };
 }
 
 function outputContext(peerName: string, contextParts: string[], systemMsg?: string): void {

--- a/plugins/honcho/src/install.ts
+++ b/plugins/honcho/src/install.ts
@@ -41,8 +41,9 @@ export function checkHooksInstalled(): boolean {
  * Check if a command is available in PATH.
  */
 export function verifyCommandAvailable(command: string): boolean {
+  const cmd = process.platform === "win32" ? `where ${command}` : `which ${command}`;
   try {
-    execSync(`which ${command}`, { stdio: "pipe" });
+    execSync(cmd, { stdio: "pipe" });
     return true;
   } catch {
     return false;

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from "fs";
 import {
   loadConfig,
   saveConfig,
+  saveRootField,
   getHonchoClientOptions,
   getSessionName,
   getConfigPath,
@@ -20,8 +21,10 @@ import {
   setDetectedHost,
   type HonchoCLAUDEConfig,
   type SessionStrategy,
+  type ReasoningLevel,
   type HonchoEnvironment,
 } from "../config.js";
+import { honchoSessionUrl } from "../styles.js";
 import {
   getLastActiveCwd,
   clearIdCache,
@@ -105,6 +108,7 @@ function handleGetConfig(cwd: string) {
     sessions: cfg.sessions ?? {},
     messageUpload: cfg.messageUpload ?? {},
     contextRefresh: cfg.contextRefresh ?? {},
+    reasoningLevel: cfg.reasoningLevel ?? "medium",
     localContext: cfg.localContext ?? {},
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
@@ -118,9 +122,12 @@ function handleGetConfig(cwd: string) {
     ? endpointInfo.type === "production" ? "platform" : endpointInfo.type
     : null;
 
+  const sessionUrl = cfg && sessionName ? honchoSessionUrl(cfg.workspace, sessionName) : null;
+
   const current = cfg ? {
     workspace: cfg.workspace,
     session: sessionName,
+    sessionUrl,
     peerName: cfg.peerName,
     aiPeer: cfg.aiPeer,
     host: `${endpointLabel} (${endpointInfo?.url})`,
@@ -265,6 +272,8 @@ function handleSetConfig(args: Record<string, unknown>) {
     case "peerName":
       previousValue = cfg.peerName;
       cfg.peerName = String(value);
+      // peerName is a global field — write to root (user-directed action)
+      saveRootField("peerName", cfg.peerName);
       clearPeerCache();
       clearUserContextOnly();
       // Clear persisted session names — they embed the peer name
@@ -291,24 +300,29 @@ function handleSetConfig(args: Record<string, unknown>) {
       }
       break;
 
-    case "endpoint.environment":
+    case "endpoint.environment": {
       previousValue = cfg.endpoint?.environment;
       if (!cfg.endpoint) cfg.endpoint = {};
       // Accept "platform" as alias for "production"
       const envVal = String(value) === "platform" ? "production" : String(value);
       cfg.endpoint.environment = envVal as HonchoEnvironment;
       cfg.endpoint.baseUrl = undefined;
+      // endpoint is a global field — write to root (user-directed action)
+      saveRootField("endpoint", cfg.endpoint);
       clearIdCache();
       clearUserContextOnly();
       clearClaudeContextOnly();
       cacheInvalidation = { cleared: ["all IDs", "all context"], reason: "Endpoint changed" };
       break;
+    }
 
     case "endpoint.baseUrl":
       previousValue = cfg.endpoint?.baseUrl;
       if (!cfg.endpoint) cfg.endpoint = {};
       cfg.endpoint.baseUrl = String(value);
       cfg.endpoint.environment = undefined;
+      // endpoint is a global field — write to root (user-directed action)
+      saveRootField("endpoint", cfg.endpoint);
       clearIdCache();
       clearUserContextOnly();
       clearClaudeContextOnly();
@@ -339,6 +353,8 @@ function handleSetConfig(args: Record<string, unknown>) {
     case "globalOverride":
       previousValue = cfg.globalOverride ?? false;
       cfg.globalOverride = Boolean(value);
+      // globalOverride is a root-level flag — write to root (user-directed)
+      saveRootField("globalOverride", cfg.globalOverride);
       break;
 
     case "enabled":
@@ -390,6 +406,11 @@ function handleSetConfig(args: Record<string, unknown>) {
       previousValue = cfg.contextRefresh?.skipDialectic;
       if (!cfg.contextRefresh) cfg.contextRefresh = {};
       cfg.contextRefresh.skipDialectic = Boolean(value);
+      break;
+
+    case "reasoningLevel":
+      previousValue = cfg.reasoningLevel ?? "medium";
+      cfg.reasoningLevel = String(value) as ReasoningLevel;
       break;
 
     case "localContext.maxEntries":
@@ -457,6 +478,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     sessions: cfg.sessions ?? {},
     messageUpload: cfg.messageUpload ?? {},
     contextRefresh: cfg.contextRefresh ?? {},
+    reasoningLevel: cfg.reasoningLevel ?? "medium",
     localContext: cfg.localContext ?? {},
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
@@ -468,6 +490,11 @@ function handleSetConfig(args: Record<string, unknown>) {
     ? "Close and restart all active Claude Code sessions. Open sessions still use the previous config and will write to the wrong Honcho session."
     : undefined;
 
+  // Include session URL when session-affecting fields change
+  const cwd = getLastActiveCwd() || process.cwd();
+  const newSessionName = SESSION_AFFECTING_FIELDS.has(field) ? getSessionName(cwd) : undefined;
+  const sessionUrl = newSessionName ? honchoSessionUrl(cfg.workspace, newSessionName) : undefined;
+
   return {
     content: [{
       type: "text",
@@ -478,6 +505,7 @@ function handleSetConfig(args: Record<string, unknown>) {
         newValue: value,
         cacheInvalidation,
         restartWarning,
+        sessionUrl,
         warnings: warnings.length ? warnings : undefined,
         resolved,
       }, null, 2),
@@ -541,6 +569,11 @@ export async function runMcpServer(): Promise<void> {
                 type: "string",
                 description: "Natural language question about the user",
               },
+              reasoning_level: {
+                type: "string",
+                enum: ["minimal", "low", "medium", "high", "max"],
+                description: "Reasoning budget for this query. Use 'low' for simple lookups, 'medium' for general questions, 'high'/'max' for complex reasoning about the user's context. Defaults to config value or 'medium'.",
+              },
             },
             required: ["query"],
           },
@@ -595,6 +628,7 @@ export async function runMcpServer(): Promise<void> {
                   "contextRefresh.messageThreshold",
                   "contextRefresh.ttlSeconds",
                   "contextRefresh.skipDialectic",
+                  "reasoningLevel",
                   "localContext.maxEntries",
                   "sessions.set",
                   "sessions.remove",
@@ -662,11 +696,12 @@ export async function runMcpServer(): Promise<void> {
 
         case "chat": {
           const query = args?.query as string;
+          const reasoningLevel = (args?.reasoning_level as string) ?? config.reasoningLevel ?? "medium";
           const userPeer = await honcho.peer(config.peerName);
 
           const response = await userPeer.chat(query, {
             session,
-            reasoningLevel: "medium",
+            reasoningLevel,
           });
 
           return {

--- a/plugins/honcho/src/pixel.ts
+++ b/plugins/honcho/src/pixel.ts
@@ -227,19 +227,23 @@ export function renderHonchoAsciiCompact(): string[] {
  * Write directly to TTY with explicit UTF-8 encoding
  * Includes escape sequence to ensure terminal is in UTF-8 mode
  */
-function writeTTY(text: string, switchToUtf8 = false): void {
+export function writeTTY(text: string, switchToUtf8 = false): void {
+  if (process.platform === "win32") {
+    if (switchToUtf8) {
+      process.stdout.write(Buffer.from("\x1b%G", "utf8"));
+    }
+    process.stdout.write(Buffer.from(text, "utf8"));
+    return;
+  }
   try {
     const fd = openSync("/dev/tty", "w");
-    // Optionally switch terminal to UTF-8 mode (ESC % G)
     if (switchToUtf8) {
       writeSync(fd, Buffer.from("\x1b%G", "utf8"));
     }
-    // Write as UTF-8 buffer explicitly
     const buffer = Buffer.from(text, "utf8");
     writeSync(fd, buffer);
     closeSync(fd);
   } catch {
-    // Fallback to stdout with UTF-8 buffer
     if (switchToUtf8) {
       process.stdout.write(Buffer.from("\x1b%G", "utf8"));
     }

--- a/plugins/honcho/src/skills/setup-runner.ts
+++ b/plugins/honcho/src/skills/setup-runner.ts
@@ -23,19 +23,39 @@ async function setup(): Promise<void> {
   console.log(s.header("honcho setup"));
   console.log("");
 
-  // Check for API key
-  const apiKey = process.env.HONCHO_API_KEY;
+  // Check for API key — env var takes precedence, then config file
+  let apiKey = process.env.HONCHO_API_KEY;
+  let keySource = "environment";
+
   if (!apiKey) {
-    console.log(s.warn("HONCHO_API_KEY is not set"));
+    // Try reading from config file
+    try {
+      const { readFileSync } = await import("fs");
+      const configRaw = readFileSync(getConfigPath(), "utf-8");
+      const configData = JSON.parse(configRaw);
+      apiKey = configData.apiKey;
+      keySource = "config";
+    } catch {
+      // No config file or no apiKey in it
+    }
+  }
+
+  if (!apiKey) {
+    console.log(s.warn("No API key found (checked env and config)"));
     console.log("");
     console.log("  1. Get a free key at https://app.honcho.dev");
-    console.log("  2. Add to ~/.zshrc or ~/.bashrc:");
-    console.log(s.dim('     export HONCHO_API_KEY="your-key-here"'));
-    console.log("  3. Restart Claude Code");
+    if (process.platform === "win32") {
+      console.log("  2. Set it in PowerShell:");
+      console.log(s.dim('     setx HONCHO_API_KEY "your-key-here"'));
+    } else {
+      console.log("  2. Add to ~/.zshrc or ~/.bashrc:");
+      console.log(s.dim('     export HONCHO_API_KEY="your-key-here"'));
+    }
+    console.log("  3. Restart Claude Code and run /honcho:setup");
     process.exit(1);
   }
 
-  console.log(s.success("HONCHO_API_KEY is set"));
+  console.log(s.success(`API key found (${keySource})`));
   console.log("");
 
   // Validate connection
@@ -68,6 +88,11 @@ async function setup(): Promise<void> {
   if (!configExists()) {
     console.log(s.section("Creating config"));
     try {
+      // Root-level globals (owned by user/CLI, written only at initial setup)
+      const { saveRootField } = await import("../config.js");
+      saveRootField("apiKey", config.apiKey);
+      saveRootField("peerName", config.peerName);
+      // Per-host config goes in hosts.claude_code via saveConfig
       saveConfig({
         apiKey: config.apiKey,
         peerName: config.peerName,

--- a/plugins/honcho/src/skills/status-runner.ts
+++ b/plugins/honcho/src/skills/status-runner.ts
@@ -5,7 +5,7 @@
  */
 import { Honcho, type Page, type Conclusion } from "@honcho-ai/sdk";
 import type { QueueStatus } from "@honcho-ai/sdk";
-import { loadConfig, getHonchoClientOptions, getEndpointInfo } from "../config.js";
+import { loadConfig, getHonchoClientOptions, getEndpointInfo, getSessionName } from "../config.js";
 import * as s from "../styles.js";
 
 async function status(): Promise<void> {
@@ -40,6 +40,7 @@ async function status(): Promise<void> {
 
     console.log(`  ${s.label("Connection")}:  ${s.success("connected")} ${s.dim(`(${latency}ms)`)}`);
     console.log(`  ${s.label("Workspace")}:   ${config.workspace} ${s.dim(`@ ${endpointInfo.url}`)}`);
+    console.log(`  ${s.label("Session")}:     ${getSessionName(process.cwd())}`);
     console.log(`  ${s.label("Peers")}:       ${config.peerName} / ${config.aiPeer}`);
 
     // Observation queue — messages being processed into conclusions

--- a/plugins/honcho/src/spinner.ts
+++ b/plugins/honcho/src/spinner.ts
@@ -101,13 +101,15 @@ export interface SpinnerOptions {
  * Write directly to the terminal, bypassing stdout/stderr capture
  */
 function writeTTY(text: string): void {
+  if (process.platform === "win32") {
+    process.stderr.write(text);
+    return;
+  }
   try {
-    // Try to write directly to /dev/tty (works on macOS/Linux)
     const fd = openSync("/dev/tty", "w");
     writeSync(fd, text);
     closeSync(fd);
   } catch {
-    // Fallback to stderr if /dev/tty not available
     process.stderr.write(text);
   }
 }
@@ -124,6 +126,8 @@ export class Spinner {
   private ttyFd: number | null = null;
   private useAscii: boolean;
 
+  private exitHandler: (() => void) | null = null;
+
   constructor(options: SpinnerOptions = {}) {
     // Auto-detect or force ASCII mode
     this.useAscii = options.style === "ascii" || !supportsUnicode();
@@ -131,6 +135,10 @@ export class Spinner {
   }
 
   private write(text: string) {
+    if (process.platform === "win32") {
+      process.stderr.write(text);
+      return;
+    }
     try {
       if (this.ttyFd === null) {
         this.ttyFd = openSync("/dev/tty", "w");
@@ -247,6 +255,22 @@ export class Spinner {
     this.message = message;
     this.frame = 0;
 
+    // Restore cursor if process exits unexpectedly (crash, timeout, signal)
+    this.exitHandler = () => {
+      try {
+        if (process.platform === "win32") {
+          process.stderr.write("\r\x1b[K\x1b[?25h");
+        } else {
+          const fd = openSync("/dev/tty", "w");
+          writeSync(fd, "\r\x1b[K\x1b[?25h");
+          closeSync(fd);
+        }
+      } catch {
+        // Best-effort cleanup
+      }
+    };
+    process.on("exit", this.exitHandler);
+
     // Hide cursor
     this.write("\x1b[?25l");
 
@@ -266,6 +290,12 @@ export class Spinner {
       this.interval = null;
     }
 
+    // Remove exit handler — clean shutdown, no longer needed
+    if (this.exitHandler) {
+      process.removeListener("exit", this.exitHandler);
+      this.exitHandler = null;
+    }
+
     // Clear line and show cursor
     this.write("\r\x1b[K\x1b[?25h");
 
@@ -282,6 +312,11 @@ export class Spinner {
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null;
+    }
+
+    if (this.exitHandler) {
+      process.removeListener("exit", this.exitHandler);
+      this.exitHandler = null;
     }
 
     this.write("\r\x1b[K\x1b[?25h");
@@ -330,8 +365,13 @@ export async function playCooldown(message = "saving memory"): Promise<void> {
   return new Promise((resolve) => {
     let frame = 0;
     let ttyFd: number | null = null;
+    let finished = false;
 
     const write = (text: string) => {
+      if (process.platform === "win32") {
+        process.stderr.write(text);
+        return;
+      }
       try {
         if (ttyFd === null) {
           ttyFd = openSync("/dev/tty", "w");
@@ -355,6 +395,17 @@ export async function playCooldown(message = "saving memory"): Promise<void> {
 
     // Hide cursor
     write("\x1b[?25l");
+
+    const exitHandler = () => {
+      if (finished) return;
+      try {
+        write("\r\x1b[K\x1b[?25h");
+      } catch {
+        // Best-effort cleanup
+      }
+      closeTTY();
+    };
+    process.on("exit", exitHandler);
 
     const frames = useAscii ? asciiCooldownFrames : cooldownFrames;
     const dots = useAscii ? ["oooo", "ooo.", "oo..", "o...", "...."] : fadeDots;
@@ -387,7 +438,9 @@ export async function playCooldown(message = "saving memory"): Promise<void> {
       frame++;
 
       if (frame >= totalFrames) {
+        finished = true;
         clearInterval(interval);
+        process.removeListener("exit", exitHandler);
         // Final clear and goodbye
         write("\r\x1b[K");
         const sparkle = useAscii ? (c.c5 + "*" + c.reset) : (c.c5 + stars.sparkle2 + c.reset);

--- a/plugins/honcho/src/styles.ts
+++ b/plugins/honcho/src/styles.ts
@@ -145,3 +145,25 @@ export function path(p: string): string {
 export function highlight(text: string): string {
   return `${colors.peach}${text}${colors.reset}`;
 }
+
+/**
+ * Build a Honcho app URL for a session
+ */
+export function honchoSessionUrl(workspace: string, sessionName: string): string {
+  return `https://app.honcho.dev/explore?workspace=${encodeURIComponent(workspace)}&view=sessions&session=${encodeURIComponent(sessionName)}`;
+}
+
+/**
+ * OSC 8 terminal hyperlink (clickable in supported terminals)
+ */
+export function hyperlink(url: string, text: string): string {
+  return `\x1b]8;;${url}\x07${text}\x1b]8;;\x07`;
+}
+
+/**
+ * Styled session line with clickable hyperlink to Honcho app
+ */
+export function sessionLine(workspace: string, sessionName: string): string {
+  const url = honchoSessionUrl(workspace, sessionName);
+  return `${colors.dim}Honcho session:${colors.reset} ${hyperlink(url, `${colors.skyBlue}${sessionName}${colors.reset}`)}`;
+}

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -50,31 +50,14 @@ export function visMessage(direction: HookDirection, hookName: string, message: 
 }
 
 /**
- * Build context injection details string
+ * Build context injection status string
  * Used by user-prompt hook (which outputs JSON systemMessage — works)
  */
 export function visContextLine(hookName: string, opts: {
-  conclusions?: number;
-  insights?: number;
   cached?: boolean;
-  cacheAge?: number;
-  sections?: number;
 }): string {
-  const parts: string[] = [];
-  if (opts.conclusions) parts.push(`${opts.conclusions} conclusions`);
-  if (opts.insights) parts.push(`${opts.insights} insights`);
-  if (opts.sections) parts.push(`${opts.sections} sections`);
-
-  let suffix = "";
-  if (opts.cached) {
-    const age = opts.cacheAge ? ` ${opts.cacheAge}s ago` : "";
-    suffix = ` (cached${age})`;
-  }
-
-  if (parts.length > 0) {
-    return formatLine("in", hookName, `injected ${parts.join(", ")}${suffix}`);
-  }
-  return "";
+  const suffix = opts.cached ? " (cached)" : "";
+  return formatLine("in", hookName, `injected conclusions${suffix}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

Restructures the plugin's hook lifecycle into a phased architecture that eliminates context timeout failures, prevents "Hook cancelled" errors on exit, and restores mid-session context freshness.

### Hook lifecycle (after)

- **session-start**: warms context cache via parallel API calls; dialectic reasoning runs fire-and-forget (results feed knowledge graph, not displayed). No stdout context injection.
- **user-prompt**: serves cached context instantly when within TTL. On stale cache or message threshold (50), fetches fresh context via `peer.context()` with a 4s timeout (within the 7s hook budget). On timeout/error, silently falls back to stale cache. User messages queued locally instead of uploaded inline.
- **session-end**: local summary saved first (survives any cancellation), then single batched API upload runs in parallel with cooldown animation. SIGTERM/SIGINT trapped during upload with a 12s hard timeout safety net to prevent unkillable processes.

### Root causes addressed

- Session-end hook did sequential `await` after `await` for 3+ API calls; Claude Code's exit process killed it mid-flight, causing "Hook cancelled" errors
- SDK timeout/retry defaults could consume the entire race budget on one slow request
- `baseUrl` / `baseURL` casing mismatch made endpoint config inert
- Scope fields (`cwd`, `sessionName`, `workspace`) in cache were always null, breaking scope matching
- Ghost `aiContext` key from older plugin versions persisted in cache file indefinitely
- Config materialization: `HONCHO_ENABLED=false` env override was being written to disk as permanent host config
- Linked host endpoint resolution was missing -- linked workspaces always hit production even when local endpoint configured
- Host key normalization: `claude-code` and `claude_code` treated as different hosts

### Key changes

| Area | Before | After |
|---|---|---|
| Context injection | session-start stdout + user-prompt | user-prompt only (session-start warms cache) |
| User message upload | Inline per-turn API call in user-prompt | Queue to disk, batch upload at session-end |
| Session-end API calls | 3+ sequential addMessages calls | Single batched addMessages call |
| Session-end ordering | API upload first, local summary after | Local summary first (survives cancellation), then API upload parallel with animation |
| Session-end signal handling | None -- killed by SIGTERM mid-upload | SIGTERM/SIGINT trapped with 12s hard timeout safety net |
| Session-end error behavior | `process.exit(1)` -- user sees error | `process.exit(0)` -- local summary already saved |
| Dialectic calls | Awaited in session-start (blocks spinner) | Fire-and-forget with `.catch()` logging |
| Config write-back | All fields written to root + host block | Root fields owned by user/CLI only; per-host via `setHostIfExplicit` |
| Config deepEqual | `JSON.stringify` comparison (key-order-sensitive) | Recursive key-order-insensitive comparison |
| SDK client options | `baseUrl` (ignored by SDK), no timeout | `baseURL`, timeout: 8s, maxRetries: 1 |
| Cache cleanup | None | Ghost key stripping on load (known-key whitelist) |
| Queue clear | After `Promise.all` (could skip on animation error) | Only after confirmed upload success |
| Spinner | No cleanup on unexpected exit | `process.on("exit")` cursor restore handler |
| Session link | Constructed eagerly on every prompt | Deferred -- only built on first message |
| Hook timeout budget | 15s | 7s (with 4s fetch timeout + cache-first architecture) |
| Visual status line | Displayed conclusion count | Simplified -- no count (unreliable with cached context) |

### Windows compatibility

- TTY writes fall back to `process.stdout`/`process.stderr` on Windows (no `/dev/tty`)
- `which` replaced with `where` for command detection
- `process.env.USERNAME` fallback for peer name resolution
- `SIGBREAK` handler alongside `SIGTERM` for Windows signal support
- Setup skill uses `setx` for environment variables, never asks for API key in chat
- New `install-local.ps1` PowerShell install script
- README updated with Windows instructions

### MCP server changes

- `get_config` includes `sessionUrl` for Honcho GUI deep link
- `set_config` returns `sessionUrl` when session-affecting fields change
- `peerName`, `endpoint`, `globalOverride` writes go through `saveRootField()` to avoid host-block pollution