### PR TITLE
feat: add glob/prefix support to session path mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
   // Session mapping
   "sessionStrategy": "per-directory", // "per-directory" | "git-branch" | "chat-instance"
   "sessionPeerPrefix": true,          // Prefix session names with peerName (default: true)
+  "sessions": {                       // Per-path overrides (exact paths and glob patterns)
+    "/Users/alice/Code/my-project": "my-custom-session",
+    "~/Code/project.worktrees/*": "my-project"
+  },
 
   // Message handling
   "saveMessages": true,
@@ -260,6 +264,27 @@ Session strategy controls how Honcho maps your conversations to sessions. Change
 | `per-directory` (default) | One session per project directory. Stable across restarts. | Most users — each project accumulates its own memory |
 | `git-branch` | Session name includes the current git branch. Switching branches switches sessions. | Feature-branch workflows where context per branch matters |
 | `chat-instance` | Each Claude Code chat gets its own session. No continuity between restarts. | Ephemeral usage, experimentation, or when you want a clean slate each time |
+
+#### Per-path overrides
+
+You can override session names for specific directories or glob patterns in the `sessions` field. This is useful for git worktree setups or monorepos where multiple directories should share a session.
+
+```jsonc
+"sessions": {
+  "~/Code/project": "my-project",
+  "~/Code/project.worktrees/*": "my-project"
+}
+```
+
+| Pattern | Matches |
+| --- | --- |
+| `/Users/alice/Code/foo` | Exact path only |
+| `~/Code/foo` | Same (tilde expands to home dir) |
+| `~/Code/*` | Any direct child of `~/Code/` |
+| `~/Code/**` | Any descendant at any depth under `~/Code/` |
+| `~/Code/work-*` | Directories starting with `work-` in `~/Code/` |
+
+Exact matches always take priority over globs. Among globs, the most specific pattern (longest literal prefix before the first wildcard) wins. Per-path overrides only apply to the `per-directory` strategy.
 
 ### Observation Mode
 

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -134,17 +134,16 @@ describe("matchSessionForPath", () => {
     expect(matchSessionForPath(`${HOME}/Code/abcdef`, sessions)).toBe("catch-all");
   });
 
-  test("relative glob patterns are resolved against cwd by resolve()", () => {
-    // **/name gets resolve()'d to an absolute path anchored at process.cwd(),
-    // so it won't work as a "match anywhere" pattern — use absolute paths instead
-    const sessions = { "**/my-project": "anywhere" };
+  test("relative paths are ignored", () => {
+    // config is global — relative keys are always a mistake
+    const sessions = { "**/my-project": "anywhere", "Code/foo": "bar" };
     expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBeNull();
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBeNull();
   });
 
-  test("empty string key is ignored", () => {
-    const sessions = { "": "oops", "~/Code/foo": "real" };
+  test("empty and relative keys are ignored", () => {
+    const sessions = { "": "oops", "relative/path": "nope", "~/Code/foo": "real" };
     expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("real");
-    // Empty key doesn't resolve to process.cwd() and match unexpectedly
     expect(matchSessionForPath(process.cwd(), sessions)).toBeNull();
   });
 

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -141,8 +141,8 @@ describe("matchSessionForPath", () => {
     expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBeNull();
   });
 
-  test("empty and relative keys are ignored", () => {
-    const sessions = { "": "oops", "relative/path": "nope", "~/Code/foo": "real" };
+  test("empty, relative, and ~prefixed-non-home keys are ignored", () => {
+    const sessions = { "": "oops", "relative/path": "nope", "~worktree": "nope", "~/Code/foo": "real" };
     expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("real");
     expect(matchSessionForPath(process.cwd(), sessions)).toBeNull();
   });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,0 +1,166 @@
+import { describe, test, expect } from "bun:test";
+import { homedir } from "os";
+import { matchSessionForPath } from "./config.js";
+
+const HOME = homedir();
+
+describe("matchSessionForPath", () => {
+  test("exact match returns session name", () => {
+    const sessions = { [`${HOME}/Code/my-project`]: "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBe("my-project");
+  });
+
+  test("exact match with tilde key matches absolute cwd", () => {
+    const sessions = { "~/Code/my-project": "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBe("my-project");
+  });
+
+  test("glob * matches direct children only", () => {
+    const sessions = { "~/Code/*": "code-catch-all" };
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("code-catch-all");
+    expect(matchSessionForPath(`${HOME}/Code/bar`, sessions)).toBe("code-catch-all");
+    expect(matchSessionForPath(`${HOME}/Code/foo/bar`, sessions)).toBeNull();
+  });
+
+  test("glob ** matches nested paths", () => {
+    const sessions = { "~/Code/**": "code-deep" };
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("code-deep");
+    expect(matchSessionForPath(`${HOME}/Code/foo/bar`, sessions)).toBe("code-deep");
+    expect(matchSessionForPath(`${HOME}/Code/foo/bar/baz`, sessions)).toBe("code-deep");
+  });
+
+  test("exact match takes priority over glob", () => {
+    const sessions = {
+      "~/Code/*": "glob-session",
+      [`${HOME}/Code/special`]: "exact-session",
+    };
+    expect(matchSessionForPath(`${HOME}/Code/special`, sessions)).toBe("exact-session");
+    expect(matchSessionForPath(`${HOME}/Code/other`, sessions)).toBe("glob-session");
+  });
+
+  test("most specific glob wins (longest literal prefix)", () => {
+    const sessions = {
+      "~/Code/*": "broad",
+      "~/Code/project-*": "specific",
+    };
+    expect(matchSessionForPath(`${HOME}/Code/project-foo`, sessions)).toBe("specific");
+    expect(matchSessionForPath(`${HOME}/Code/other`, sessions)).toBe("broad");
+  });
+
+  test("trailing slash on cwd is normalized", () => {
+    const sessions = { "~/Code/my-project": "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project/`, sessions)).toBe("my-project");
+  });
+
+  test("trailing slash on config key is normalized", () => {
+    const sessions = { "~/Code/my-project/": "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBe("my-project");
+  });
+
+  test("glob ** does not match the base directory itself", () => {
+    const sessions = { "~/Code/**": "code-deep" };
+    expect(matchSessionForPath(`${HOME}/Code`, sessions)).toBeNull();
+  });
+
+  test("resolve handles .. segments in config keys", () => {
+    const sessions = { "~/Code/../Code/my-project": "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBe("my-project");
+  });
+
+  test("resolve handles .. segments in cwd", () => {
+    const sessions = { "~/Code/my-project": "my-project" };
+    expect(matchSessionForPath(`${HOME}/Code/other/../my-project`, sessions)).toBe("my-project");
+  });
+
+  test("equal specificity globs break ties by pattern length", () => {
+    // Both patterns have first metachar at the same index (after ~/Code/ab)
+    const sessions = {
+      "~/Code/ab*": "shorter",
+      "~/Code/ab*-extra": "longer",
+    };
+    // "longer" pattern has greater total length, so it's checked first
+    expect(matchSessionForPath(`${HOME}/Code/ab-test-extra`, sessions)).toBe("longer");
+    // But a path that only matches the shorter pattern still works
+    expect(matchSessionForPath(`${HOME}/Code/ab-test`, sessions)).toBe("shorter");
+  });
+
+  test("no match returns null", () => {
+    const sessions = { "~/Code/*": "code-session" };
+    expect(matchSessionForPath(`${HOME}/Other/project`, sessions)).toBeNull();
+  });
+
+  test("empty sessions returns null", () => {
+    expect(matchSessionForPath(`${HOME}/Code/foo`, {})).toBeNull();
+  });
+
+  test("brace expansion matches multiple alternatives", () => {
+    const sessions = { "~/Code/{frontend,backend}": "mono-session" };
+    expect(matchSessionForPath(`${HOME}/Code/frontend`, sessions)).toBe("mono-session");
+    expect(matchSessionForPath(`${HOME}/Code/backend`, sessions)).toBe("mono-session");
+    expect(matchSessionForPath(`${HOME}/Code/infra`, sessions)).toBeNull();
+  });
+
+  test("? wildcard matches single character", () => {
+    const sessions = { "~/Code/v?": "versioned" };
+    expect(matchSessionForPath(`${HOME}/Code/v1`, sessions)).toBe("versioned");
+    expect(matchSessionForPath(`${HOME}/Code/v2`, sessions)).toBe("versioned");
+    expect(matchSessionForPath(`${HOME}/Code/v10`, sessions)).toBeNull();
+  });
+
+  test("[...] character class matches specified characters", () => {
+    const sessions = { "~/Code/[abc]-project": "abc-session" };
+    expect(matchSessionForPath(`${HOME}/Code/a-project`, sessions)).toBe("abc-session");
+    expect(matchSessionForPath(`${HOME}/Code/b-project`, sessions)).toBe("abc-session");
+    expect(matchSessionForPath(`${HOME}/Code/z-project`, sessions)).toBeNull();
+  });
+
+  test("** vs * specificity: ** wins tie-break by length for direct children", () => {
+    const sessions = {
+      "~/Code/*": "shallow",
+      "~/Code/**": "deep",
+    };
+    // Both match, ** is longer so it sorts first and wins
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("deep");
+    // Only ** matches nested
+    expect(matchSessionForPath(`${HOME}/Code/foo/bar`, sessions)).toBe("deep");
+  });
+
+  test("longer non-matching glob falls through to shorter matching glob", () => {
+    const sessions = {
+      "~/Code/ab*": "catch-all",
+      "~/Code/ab*/deep/**": "deep-only",
+    };
+    // deep-only sorts first (longer) but doesn't match — falls through to catch-all
+    expect(matchSessionForPath(`${HOME}/Code/abcdef`, sessions)).toBe("catch-all");
+  });
+
+  test("relative glob patterns are resolved against cwd by resolve()", () => {
+    // **/name gets resolve()'d to an absolute path anchored at process.cwd(),
+    // so it won't work as a "match anywhere" pattern — use absolute paths instead
+    const sessions = { "**/my-project": "anywhere" };
+    expect(matchSessionForPath(`${HOME}/Code/my-project`, sessions)).toBeNull();
+  });
+
+  test("empty string key is ignored", () => {
+    const sessions = { "": "oops", "~/Code/foo": "real" };
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBe("real");
+    // Empty key doesn't resolve to process.cwd() and match unexpectedly
+    expect(matchSessionForPath(process.cwd(), sessions)).toBeNull();
+  });
+
+  test("empty string session value is ignored", () => {
+    const sessions = { "~/Code/foo": "" };
+    // Empty values are skipped to avoid falsy-value bugs in consumers
+    expect(matchSessionForPath(`${HOME}/Code/foo`, sessions)).toBeNull();
+  });
+
+  test("worktree glob pattern matches worktree directories", () => {
+    const sessions = {
+      "~/Code/project": "my-project",
+      "~/Code/project.worktrees/*": "my-project",
+    };
+    expect(matchSessionForPath(`${HOME}/Code/project`, sessions)).toBe("my-project");
+    expect(matchSessionForPath(`${HOME}/Code/project.worktrees/branch-1`, sessions)).toBe("my-project");
+    expect(matchSessionForPath(`${HOME}/Code/project.worktrees/branch-2`, sessions)).toBe("my-project");
+  });
+});

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,5 +1,5 @@
 import { homedir } from "os";
-import { join, basename, resolve } from "path";
+import { join, basename, resolve, isAbsolute } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
@@ -549,7 +549,7 @@ export function matchSessionForPath(cwd: string, sessions: Record<string, string
 
   // Skip empty entries and relative paths (config is global, relative keys are always a mistake)
   const entries = Object.entries(sessions).filter(
-    ([key, name]) => key && name && (key.startsWith("/") || key.startsWith("~")),
+    ([key, name]) => key && name && (key === "~" || key.startsWith("~/") || isAbsolute(key)),
   );
 
   for (const [key, name] of entries) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -547,8 +547,10 @@ export function getClaudeSettingsDir(): string {
 export function matchSessionForPath(cwd: string, sessions: Record<string, string>): string | null {
   const normalizedCwd = normalizePath(cwd);
 
-  // Skip entries with empty keys or empty values
-  const entries = Object.entries(sessions).filter(([key, name]) => key && name);
+  // Skip empty entries and relative paths (config is global, relative keys are always a mistake)
+  const entries = Object.entries(sessions).filter(
+    ([key, name]) => key && name && (key.startsWith("/") || key.startsWith("~")),
+  );
 
   for (const [key, name] of entries) {
     if (!isGlobPattern(key) && normalizePath(key) === normalizedCwd) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,11 +1,25 @@
 import { homedir } from "os";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
 
 function sanitizeForSessionName(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
+}
+
+const GLOB_META_RE = /[*?[\]{]/;
+
+function normalizePath(p: string): string {
+  let result = p;
+  if (result.startsWith("~/") || result === "~") {
+    result = join(homedir(), result.slice(1));
+  }
+  return resolve(result);
+}
+
+function isGlobPattern(pattern: string): boolean {
+  return GLOB_META_RE.test(pattern);
 }
 
 export interface MessageUploadConfig {
@@ -529,10 +543,41 @@ export function getClaudeSettingsDir(): string {
   return join(homedir(), ".claude");
 }
 
+/** Match a cwd against a sessions map, checking exact paths first then globs by specificity. */
+export function matchSessionForPath(cwd: string, sessions: Record<string, string>): string | null {
+  const normalizedCwd = normalizePath(cwd);
+
+  // Skip entries with empty keys or empty values
+  const entries = Object.entries(sessions).filter(([key, name]) => key && name);
+
+  for (const [key, name] of entries) {
+    if (!isGlobPattern(key) && normalizePath(key) === normalizedCwd) {
+      return name;
+    }
+  }
+
+  const globEntries = entries
+    .filter(([key]) => isGlobPattern(key))
+    .map(([key, name]) => {
+      const normalized = normalizePath(key);
+      const firstMeta = normalized.search(GLOB_META_RE);
+      return { pattern: normalized, name, specificity: firstMeta === -1 ? normalized.length : firstMeta };
+    })
+    .sort((a, b) => b.specificity - a.specificity || b.pattern.length - a.pattern.length);
+
+  for (const { pattern, name } of globEntries) {
+    if (new Bun.Glob(pattern).match(normalizedCwd)) {
+      return name;
+    }
+  }
+
+  return null;
+}
+
 export function getSessionForPath(cwd: string): string | null {
   const config = loadConfig();
   if (!config?.sessions) return null;
-  return config.sessions[cwd] || null;
+  return matchSessionForPath(cwd, config.sessions);
 }
 
 /** Session name derived from strategy. Manual overrides only apply to per-directory.


### PR DESCRIPTION
## Summary

- Adds glob pattern support to the `sessions` config field so entries like `~/Code/project.worktrees/*` match multiple directories to the same session name
- Exact paths take priority over globs; among globs, the most specific pattern (longest literal prefix) wins
- Tilde expansion and `path.resolve()` normalization on both keys and cwd
- Empty keys/values silently skipped to prevent ghost matches
- Uses `Bun.Glob` for matching — zero new dependencies
- 23 tests covering exact match, globs (`*`, `**`, `?`, `[...]`, `{a,b}`), specificity ordering, normalization, and edge cases

## Motivation

Users with git worktree setups need to map multiple directories to the same session without adding an explicit config entry per path:

```json
{
  "sessions": {
    "~/Code/project": "my-project",
    "~/Code/project.worktrees/*": "my-project"
  }
}
```

## Test plan

- [x] `bun test src/config.test.ts` — 23/23 passing
- [x] `bunx tsc --noEmit` — clean
- [ ] Manual: add glob entries to `~/.honcho/config.json`, launch Claude Code in matching directories, verify session name via `/honcho:status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-path session name overrides via exact paths and glob patterns for flexible session configuration; exact matches outrank globs and the most specific glob wins; applies only to the per-directory session strategy

* **Documentation**
  * Added "Per-path overrides" guide with example mappings and a pattern-matching reference table

* **Tests**
  * Added comprehensive tests covering exact matches, glob semantics, precedence, normalization, and edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->