### PR TITLE
chore: remove dead linkedHosts scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ All configuration lives in a single global file at `~/.honcho/config.json`. You 
     "claude_code": {
       "workspace": "claude_code",   // Workspace for Claude Code sessions
       "aiPeer": "claude",           // AI identity in this workspace
-      "linkedHosts": ["cursor"]     // Read context from these other hosts (optional)
     },
     "cursor": {
       "workspace": "cursor",
@@ -358,29 +357,6 @@ The plugin auto-detects which tool is running it (Claude Code, Cursor, etc.) and
 2. `cursor_version` in hook stdin (Cursor detected)
 3. `CURSOR_PROJECT_DIR` env var (Cursor child process)
 4. Default: `claude_code`
-
-### Linking Hosts for Cross-Tool Context
-
-If you use both Claude Code and Cursor, you can link them so context from one is readable in the other. Writes always stay in the current host's workspace — linking only adds read access.
-
-```jsonc
-{
-  "hosts": {
-    "claude_code": {
-      "workspace": "claude_code",
-      "aiPeer": "claude",
-      "linkedHosts": ["cursor"]  // Claude Code can read Cursor's context
-    },
-    "cursor": {
-      "workspace": "cursor",
-      "aiPeer": "cursor",
-      "linkedHosts": ["claude_code"]  // Cursor can read Claude Code's context
-    }
-  }
-}
-```
-
-Or use the `/honcho:config` skill and select **Workspace > Linking** to set this up interactively.
 
 ### Global Override
 

--- a/plugins/honcho/skills/config/SKILL.md
+++ b/plugins/honcho/skills/config/SKILL.md
@@ -37,7 +37,7 @@ AskUserQuestion:
     - label: "Session mapping"
       description: "How sessions are named — per directory, git branch, or per chat (currently: {resolved.sessionStrategy})"
     - label: "Workspace"
-      description: "Data space, linking, and cross-tool context (currently: {resolved.workspace})"
+      description: "Data space and session scope (currently: {resolved.workspace})"
 ```
 
 If the user selects "Other", present advanced options:
@@ -121,8 +121,6 @@ AskUserQuestion:
   options:
     - label: "Rename workspace"
       description: "Change workspace name (currently: {resolved.workspace})"
-    - label: "Link / unlink hosts"
-      description: "Share context across tools (currently: {resolved.linkedHosts || 'none'})"
 ```
 
 #### Workspace > Rename
@@ -141,59 +139,6 @@ AskUserQuestion:
 ```
 
 If confirmed, call `set_config` again WITH `confirm: true`.
-
-#### Workspace > Link / unlink hosts
-
-Linking and global mode are one concept: if any hosts are linked, global mode is on (shared workspace, sessions, peers). If all hosts are unlinked, global mode is off.
-
-Show one option per host. Each option is either "Link {host}" or "Unlink {host}" depending on current state. Do NOT use multiSelect — use single-select so only one action happens at a time.
-
-```
-AskUserQuestion:
-  question: "Link or unlink a host:"
-  header: "Link"
-  options:
-    - label: "Unlink {hostKey}"              // for each host in resolved.linkedHosts
-      description: "Currently linked (workspace: {hostWorkspace})"
-    - label: "Link {hostKey}"                // for each host NOT in resolved.linkedHosts
-      description: "workspace: {hostWorkspace}"
-    (one option per host from get_config's host.otherHosts)
-```
-
-**If the user chose "Link {host}":**
-
-Compute the new linked array: current `resolved.linkedHosts` + the new host.
-Call `set_config` with `field: "linkedHosts"` and the new array.
-
-If this is the first link (was previously empty), prompt for shared workspace:
-
-```
-AskUserQuestion:
-  question: "Shared workspace name?"
-  header: "Workspace"
-  options:
-    - label: "{currentWorkspace} (Recommended)"
-      description: "Keep the current workspace"
-    - label: "{otherHostWorkspace}"
-      description: "Use {otherHost}'s workspace"
-    (one option per unique workspace among linked hosts + current host)
-```
-
-Call `set_config` with `field: "workspace"`, `value: chosen`, `confirm: true`.
-Call `set_config` with `field: "globalOverride"`, `value: true`, `confirm: true`.
-
-If already linked to other hosts (just adding one more), skip the workspace prompt — the shared workspace is already set.
-
-**If the user chose "Unlink {host}":**
-
-Compute the new linked array: current `resolved.linkedHosts` minus that host.
-Call `set_config` with `field: "linkedHosts"` and the new array.
-
-If the new array is empty (no hosts linked), also disable global mode:
-Call `set_config` with `field: "globalOverride"`, `value: false`.
-Explain: "All hosts unlinked. Each host uses its own workspace and config."
-
-If hosts remain linked, just confirm: "Unlinked {host}. Still linked to: {remaining}."
 
 ### Dangerous fields (Host)
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -62,8 +62,7 @@ export interface HostConfig {
   workspace?: string;
   /** AI peer name for this host (e.g. "claude", "cursor") */
   aiPeer?: string;
-  /** Other host keys whose workspaces to read context from (writes stay local) */
-  linkedHosts?: string[];
+
   /** Per-host overrides for settings that may differ across tools */
   enabled?: boolean;
   logging?: boolean;
@@ -198,8 +197,7 @@ export interface HonchoCLAUDEConfig {
   workspace: string;
   /** AI peer name (resolved per-host, e.g. "claude" for claude-code) */
   aiPeer: string;
-  /** Other host keys whose workspaces to also read context from */
-  linkedHosts?: string[];
+
   /** How sessions are named: per-directory, git-branch, or chat-instance */
   sessionStrategy?: SessionStrategy;
   /** Prefix session names with peerName (default: true, disable for solo use) */
@@ -315,9 +313,6 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     }
   }
 
-  // Resolve linked hosts
-  const linkedHosts = hostBlock?.linkedHosts ?? [];
-
   // Per-host settings: check hosts.<name>.X first, fall back to root X.
   // This lets the user set global defaults at root (via CLI) while
   // individual integrations can override per-host without touching root.
@@ -326,7 +321,6 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     peerName,
     workspace,
     aiPeer,
-    linkedHosts: linkedHosts.length ? linkedHosts : undefined,
     sessionStrategy: hostBlock?.sessionStrategy ?? raw.sessionStrategy,
     sessionPeerPrefix: hostBlock?.sessionPeerPrefix ?? raw.sessionPeerPrefix,
     sessions: raw.sessions,
@@ -451,7 +445,6 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   const existingHost: HostConfig = existing.hosts[host] ?? {};
 
   const hostEntry: HostConfig = {};
-  if (config.linkedHosts?.length) hostEntry.linkedHosts = config.linkedHosts;
 
   const setHostIfExplicit = <K extends keyof HostConfig>(
     key: K,
@@ -645,56 +638,7 @@ export function setPluginEnabled(enabled: boolean): void {
   saveConfig(config);
 }
 
-/**
- * Linked host workspace + endpoint resolution from raw config.
- * Endpoint falls back to root endpoint when the host block omits it.
- */
-export interface LinkedWorkspaceConfig {
-  hostKey: string;
-  workspace: string;
-  endpoint?: HonchoEndpointConfig;
-}
 
-export function getLinkedWorkspaceConfigs(): LinkedWorkspaceConfig[] {
-  const config = loadConfig();
-  if (!config?.linkedHosts?.length) return [];
-
-  const cfgPath = getConfigPath();
-  if (!existsSync(cfgPath)) return [];
-
-  let raw: HonchoFileConfig;
-  try {
-    raw = JSON.parse(readFileSync(cfgPath, "utf-8")) as HonchoFileConfig;
-  } catch {
-    return [];
-  }
-
-  const linked: LinkedWorkspaceConfig[] = [];
-  for (const hostKey of config.linkedHosts) {
-    // Normalize: try exact key, then underscore, then dash variants
-    const block = raw.hosts?.[hostKey]
-      ?? raw.hosts?.[hostKey.replace(/-/g, "_")]
-      ?? raw.hosts?.[hostKey.replace(/_/g, "-")];
-    // Use that host's configured workspace, or fall back to host key as workspace name
-    const ws = block?.workspace ?? hostKey;
-    // Don't include our own workspace
-    if (ws !== config.workspace) {
-      linked.push({
-        hostKey,
-        workspace: ws,
-        endpoint: block?.endpoint ?? raw.endpoint,
-      });
-    }
-  }
-  return linked;
-}
-
-/**
- * Get workspace names from linked hosts.
- */
-export function getLinkedWorkspaces(): string[] {
-  return getLinkedWorkspaceConfigs().map((entry) => entry.workspace);
-}
 
 /**
  * Get all known host keys from the config file's hosts block.

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -17,7 +17,6 @@ import {
   getDetectedHost,
   getEndpointInfo,
   getKnownHosts,
-  getLinkedWorkspaces,
   setDetectedHost,
   type HonchoCLAUDEConfig,
   type SessionStrategy,
@@ -95,7 +94,6 @@ function handleGetConfig(cwd: string) {
   }
 
   // Resolved config
-  const linkedWorkspaces = getLinkedWorkspaces();
   const globalOverride = rawFile.globalOverride === true;
   const resolved = cfg ? {
     peerName: cfg.peerName,
@@ -105,8 +103,6 @@ function handleGetConfig(cwd: string) {
     globalOverride,
     sessionStrategy: cfg.sessionStrategy ?? "per-directory",
     sessionPeerPrefix: cfg.sessionPeerPrefix !== false,
-    linkedHosts: cfg.linkedHosts ?? [],
-    linkedWorkspaces,
     sessions: cfg.sessions ?? {},
     messageUpload: cfg.messageUpload ?? {},
     contextRefresh: cfg.contextRefresh ?? {},
@@ -192,13 +188,10 @@ function handleGetConfig(cwd: string) {
         ? `local (${endpointInfo.url})`
         : endpointInfo.url
     : "unknown";
-  const linkedLabel = resolved?.linkedHosts?.length
-    ? resolved.linkedHosts.join(", ")
-    : "none";
 
   const card = cfg ? renderCard([
     ["workspace", cfg.workspace],
-    ["linked", linkedLabel],
+
     ["session", sessionName ?? "unknown"],
     ["mapping", strategyLabels[cfg.sessionStrategy ?? "per-directory"] ?? cfg.sessionStrategy ?? "per directory"],
     ["peer", `${cfg.peerName} / ${cfg.aiPeer}`],
@@ -347,12 +340,6 @@ function handleSetConfig(args: Record<string, unknown>) {
       cfg.sessions = {};
       break;
 
-    case "linkedHosts": {
-      previousValue = cfg.linkedHosts ?? [];
-      const hosts = Array.isArray(value) ? value.map(String) : [];
-      cfg.linkedHosts = hosts.length ? hosts : undefined;
-      break;
-    }
 
     case "globalOverride":
       previousValue = cfg.globalOverride ?? false;
@@ -474,7 +461,6 @@ function handleSetConfig(args: Record<string, unknown>) {
 
   // Return updated resolved config
   const endpointInfo = getEndpointInfo(cfg);
-  const updatedLinkedWorkspaces = getLinkedWorkspaces();
   const resolved = {
     peerName: cfg.peerName,
     aiPeer: cfg.aiPeer,
@@ -482,8 +468,6 @@ function handleSetConfig(args: Record<string, unknown>) {
     endpoint: endpointInfo,
     sessionStrategy: cfg.sessionStrategy ?? "per-directory",
     sessionPeerPrefix: cfg.sessionPeerPrefix !== false,
-    linkedHosts: cfg.linkedHosts ?? [],
-    linkedWorkspaces: updatedLinkedWorkspaces,
     sessions: cfg.sessions ?? {},
     messageUpload: cfg.messageUpload ?? {},
     contextRefresh: cfg.contextRefresh ?? {},
@@ -689,7 +673,6 @@ export async function runMcpServer(): Promise<void> {
                   "endpoint.baseUrl",
                   "sessionStrategy",
                   "sessionPeerPrefix",
-                  "linkedHosts",
                   "enabled",
                   "logging",
                   "saveMessages",


### PR DESCRIPTION
## Summary

The `linkedHosts` feature (cross-workspace context fetching) was added in `e8bf2fa` (Feb 25) and fully removed in `61bc60e` (Mar 24) during the resilience refactor. The config scaffolding, status display, config tool case, and documentation survived but nothing calls it at runtime — the functions are dead code.

## Changes

**`plugins/honcho/src/config.ts`**
- Remove `HostConfig.linkedHosts` field
- Remove `HonchoCLAUDEConfig.linkedHosts` field
- Remove `LinkedWorkspaceConfig` interface
- Remove `getLinkedWorkspaceConfigs()` and `getLinkedWorkspaces()` functions
- Remove linked host resolution from `loadConfig()`
- Remove linked host persistence from `saveConfig()`

**`plugins/honcho/src/mcp/server.ts`**
- Remove `getLinkedWorkspaces` import
- Remove `linkedWorkspaces` / `linkedHosts` from resolved config objects
- Remove `linked` label from status card
- Remove `linkedHosts` case from `set_config` tool handler
- Remove `linkedHosts` from config field enum

**`README.md`**
- Remove `linkedHosts` from config example
- Remove "Linking Hosts for Cross-Tool Context" section

**`plugins/honcho/skills/config/SKILL.md`**
- Remove "Link / unlink hosts" option from Workspace menu
- Remove entire link/unlink host flow documentation

## Context

Prompted by [honcho#471](https://github.com/plastic-labs/honcho/issues/471) — an issue filed against the wrong repo (honcho server vs claude-honcho plugin) that referenced stale code from before the Mar 24 refactor. The core observation was valid: the docs and config still promised linked workspace functionality that no longer exists at runtime.

**4 files changed, 4 insertions, 156 deletions** — pure cleanup, no behavioral changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed cross-tool host linking documentation and configuration examples from README and configuration guide.

* **Refactor**
  * Removed host linking functionality from the Workspace menu and configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->