### PR TITLE
chore: sync marketplace.json to 0.2.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "honcho-dev",
       "source": "./plugins/honcho-dev",
       "description": "Skills for building AI applications with the Honcho SDK",
-      "version": "0.1.3",
+      "version": "0.2.4",
       "keywords": ["sdk", "development", "migration"],
       "strict": false
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Honcho plugins for Claude Code - memory, development tools, and more",
-    "version": "0.2.0"
+    "version": "0.2.4"
   },
   "plugins": [
     {
       "name": "honcho",
       "source": "./plugins/honcho",
       "description": "Persistent memory for Claude Code sessions using Honcho",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "keywords": ["memory", "context", "persistence"],
       "strict": false
     },
@@ -21,7 +21,7 @@
       "name": "honcho-dev",
       "source": "./plugins/honcho-dev",
       "description": "Skills for building AI applications with the Honcho SDK",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "keywords": ["sdk", "development", "migration"],
       "strict": false
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "honcho-dev",
       "source": "./plugins/honcho-dev",
       "description": "Skills for building AI applications with the Honcho SDK",
-      "version": "0.2.4",
+      "version": "0.1.3",
       "keywords": ["sdk", "development", "migration"],
       "strict": false
     }

--- a/plugins/honcho-dev/.claude-plugin/plugin.json
+++ b/plugins/honcho-dev/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho-dev",
-  "version": "0.1.3",
+  "version": "0.2.4",
   "description": "Skills for building AI applications with the Honcho SDK",
   "author": {
     "name": "Plastic Labs",

--- a/plugins/honcho/.claude-plugin/plugin.json
+++ b/plugins/honcho/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "honcho",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "Persistent memory for Claude Code sessions using Honcho by Plastic Labs",
   "author": {
     "name": "Plastic Labs",


### PR DESCRIPTION
Bumps all version fields in `.claude-plugin/marketplace.json` from `0.2.0` to `0.2.4` to match `package.json`.

`marketplace.json` was never updated across the 0.2.1–0.2.4 release cycle, causing the Claude Code marketplace to advertise stale version info and blocking update detection for existing installs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated manifest and plugin entries to version 0.2.4 for consistency across the marketplace and both Honcho plugins (honcho and honcho-dev), ensuring all published plugin versions are aligned with the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->