### PR TITLE
fix: make Honcho SDK timeout configurable (closes #25)

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -175,6 +175,9 @@ interface HonchoFileConfig {
   reasoningLevel?: ReasoningLevel;
   /** Observation mode (default: "unified") */
   observationMode?: ObservationMode;
+  /** HTTP timeout (ms) for Honcho SDK requests (default: 30000).
+   *  Raise for high/max dialectic reasoning levels that may exceed 8s. */
+  sdkTimeout?: number;
   hosts?: Record<string, HostConfig>;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts,
    *  ignoring host-specific blocks. When false (default), each host
@@ -226,8 +229,20 @@ export interface HonchoCLAUDEConfig {
   enabled?: boolean;
   /** Enable file logging to ~/.honcho/ (default: true) */
   logging?: boolean;
+  /** HTTP timeout (ms) for Honcho SDK requests (default: 30000).
+   *  Dialectic chat at high/max reasoning levels can exceed 8s; increase
+   *  this to avoid client-side aborts. Overridable via HONCHO_TIMEOUT env. */
+  sdkTimeout?: number;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+}
+
+/** Parse HONCHO_TIMEOUT env var into a positive integer, or undefined. */
+function parseTimeoutEnv(): number | undefined {
+  const raw = process.env.HONCHO_TIMEOUT;
+  if (!raw) return undefined;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -333,6 +348,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     localContext: hostBlock?.localContext ?? raw.localContext,
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
+    sdkTimeout: parseTimeoutEnv() ?? raw.sdkTimeout,
     globalOverride: raw.globalOverride,
   };
 
@@ -367,6 +383,7 @@ export function loadConfigFromEnv(host?: HonchoHost): HonchoCLAUDEConfig | null 
     saveMessages: process.env.HONCHO_SAVE_MESSAGES !== "false",
     enabled: process.env.HONCHO_ENABLED !== "false",
     logging: process.env.HONCHO_LOGGING !== "false",
+    sdkTimeout: parseTimeoutEnv(),
   };
 
   if (endpoint) {
@@ -692,12 +709,16 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
   return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
+/** Default SDK HTTP timeout (ms). Raised from 8000 to accommodate
+ *  multi-turn dialectic chat at high/max reasoning levels. See #25. */
+export const DEFAULT_SDK_TIMEOUT_MS = 30000;
+
 export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
-    timeout: 8000,
+    timeout: config.sdkTimeout ?? DEFAULT_SDK_TIMEOUT_MS,
     maxRetries: 1,
   };
 }


### PR DESCRIPTION
Closes #25.

## What this does

Replaces the hardcoded `timeout: 8000` in `getHonchoClientOptions()` with a configurable value.

**Precedence:** `HONCHO_TIMEOUT` env var → `config.sdkTimeout` (on-disk) → `DEFAULT_SDK_TIMEOUT_MS` (30000).

## Why

As documented in #25, 8s aborts dialectic chat at `high`/`max` reasoning levels even with healthy backends, because multi-iteration tool loops on local models (LM Studio/Ollama) or rich observation sets regularly take 10-30s. 30s matches the issue's primary suggestion and leaves headroom without matching the SDK's 60s default (which felt too generous as a new default). Users who want 60s can set `HONCHO_TIMEOUT=60000` or add `"sdkTimeout": 60000` to their config.

## Changes

- `HonchoFileConfig` (on-disk shape): added `sdkTimeout?: number` so the value survives `saveConfig()`.
- `HonchoCLAUDEConfig` (resolved runtime shape): added `sdkTimeout?: number` with doc comment citing #25.
- New `parseTimeoutEnv()` helper: reads `HONCHO_TIMEOUT`, coerces to a positive finite integer, returns `undefined` on invalid input so the next precedence level wins.
- `resolveConfig()`: env var first, then `raw.sdkTimeout` from the file.
- `loadConfigFromEnv()`: env var only.
- `getHonchoClientOptions()`: `config.sdkTimeout ?? DEFAULT_SDK_TIMEOUT_MS`.
- Exported `DEFAULT_SDK_TIMEOUT_MS = 30000` replaces the magic number.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] Verified with no env + no config field → 30000
- [x] Verified with `HONCHO_TIMEOUT=45000` → 45000 (parsed as positive int)
- [x] Verified with invalid `HONCHO_TIMEOUT=abc` → falls through to file/default
- [x] File-config `sdkTimeout: 20000` with no env var → 20000

## Not included

- Per-tool timeouts (alternative mentioned in #25). Scoped out here to keep the change minimal; happy to follow up if maintainers prefer that shape.
- Changes to the 4s hook race in `user-prompt.ts` — that's a separate UX fallback (serves stale context on slow `peer.context()` calls) and doesn't hard-fail, so it's out of scope for #25.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added configurable SDK timeout via the `HONCHO_TIMEOUT` environment variable
* Updated default SDK timeout to 30 seconds (previously 8 seconds)
* Added optional `sdkTimeout` configuration setting for granular timeout control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->