### PR TITLE
feat(config): HONCHO_PROFILE env var for per-session identity routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `HONCHO_PROFILE` environment variable enables per-session identity routing. When set, `resolveConfig` looks up a profile-suffixed host block (`hosts.<host>.<profile>`, e.g. `hosts.claude_code.director`) before falling back to the bare host block. The new `profile` field on `HonchoCLAUDEConfig` surfaces the active value for diagnostics (e.g. via MCP `get_config`). Setting `HONCHO_PROFILE` during a `saveConfig` call emits a stderr warning since writes always target the bare block; profile blocks are hand-curated.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
+| `HONCHO_PROFILE`       | No       | unset         | Selects `hosts.<host>.<profile>` block; falls back to bare `hosts.<host>` when unset or no match (with stderr warning). Useful for routing different projects to different identities. |
 
 ## How It Works
 

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -74,4 +74,20 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.aiPeer).toBe("director-7stars");
     expect(config!.profile).toBe("director-7stars");
   });
+
+  test("profile suffix with hyphens not corrupted by alias chain", () => {
+    process.env.HONCHO_PROFILE = "director-7stars";
+    const rawAmbiguous: HonchoFileConfig = {
+      ...baseRaw,
+      hosts: {
+        ...baseRaw.hosts,
+        "claude_code.director-7stars": { workspace: "7stars-dash",  aiPeer: "director-dash"  },
+        "claude_code.director_7stars": { workspace: "7stars-under", aiPeer: "director-under" },
+      },
+    };
+    const config = resolveConfig(rawAmbiguous, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars-dash");
+    expect(config!.aiPeer).toBe("director-dash");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, warnIfProfileRoutedSave, type HonchoFileConfig } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -7,6 +7,7 @@ const ORIG_API_KEY = process.env.HONCHO_API_KEY;
 beforeEach(() => {
   delete process.env.HONCHO_PROFILE;
   delete process.env.HONCHO_API_KEY;
+  _resetProfileWarnCacheForTests();
 });
 
 afterEach(() => {
@@ -73,6 +74,38 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.workspace).toBe("7stars");
     expect(config!.aiPeer).toBe("director-7stars");
     expect(config!.profile).toBe("director-7stars");
+  });
+
+  test("HONCHO_PROFILE sanitizing to empty → bare block, no warning", () => {
+    process.env.HONCHO_PROFILE = "...";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      const config = resolveConfig(baseRaw, "claude_code");
+      expect(config).not.toBeNull();
+      expect(config!.workspace).toBe("hermes");
+      expect(config!.aiPeer).toBe("coder");
+      expect(config!.profile).toBeUndefined();
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("missing-profile warning dedupes across multiple resolveConfig calls", () => {
+    process.env.HONCHO_PROFILE = "ghost";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      resolveConfig(baseRaw, "claude_code");
+      resolveConfig(baseRaw, "claude_code");
+      resolveConfig(baseRaw, "claude_code");
+      const matching = stderrSpy.mock.calls
+        .map(call => String(call[0]))
+        .filter(msg => msg.includes("HONCHO_PROFILE=ghost"));
+      expect(matching.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   test("profile suffix with hyphens not corrupted by alias chain", () => {

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -31,4 +31,13 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.aiPeer).toBe("coder");
     expect(config!.profile).toBeUndefined();
   });
+
+  test("HONCHO_PROFILE=director + matching block → returns profile block", () => {
+    process.env.HONCHO_PROFILE = "director";
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars");
+    expect(config!.aiPeer).toBe("director");
+    expect(config!.profile).toBe("director");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { resolveConfig, type HonchoFileConfig } from "./config";
+import { warnIfProfileRoutedSave } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -89,5 +90,46 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config).not.toBeNull();
     expect(config!.workspace).toBe("7stars-dash");
     expect(config!.aiPeer).toBe("director-dash");
+  });
+});
+
+describe("warnIfProfileRoutedSave — profile-routed write guard", () => {
+  test("HONCHO_PROFILE set → writes warning to stderr", () => {
+    process.env.HONCHO_PROFILE = "director";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg =>
+        msg.includes("HONCHO_PROFILE=director") &&
+        msg.includes("hand-curated")
+      )).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE unset → no stderr output", () => {
+    delete process.env.HONCHO_PROFILE;
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE empty string → no stderr output", () => {
+    process.env.HONCHO_PROFILE = "";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -58,4 +58,20 @@ describe("resolveConfig — profile-aware host block lookup", () => {
       stderrSpy.mockRestore();
     }
   });
+
+  test("HONCHO_PROFILE with illegal chars → sanitized to dash, matches sanitized block", () => {
+    process.env.HONCHO_PROFILE = "director.7stars";
+    const rawWithSanitizedBlock: HonchoFileConfig = {
+      ...baseRaw,
+      hosts: {
+        ...baseRaw.hosts,
+        "claude_code.director-7stars": { workspace: "7stars", aiPeer: "director-7stars" },
+      },
+    };
+    const config = resolveConfig(rawWithSanitizedBlock, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars");
+    expect(config!.aiPeer).toBe("director-7stars");
+    expect(config!.profile).toBe("director-7stars");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { resolveConfig, type HonchoFileConfig } from "./config";
+
+const ORIG_PROFILE = process.env.HONCHO_PROFILE;
+const ORIG_API_KEY = process.env.HONCHO_API_KEY;
+
+beforeEach(() => {
+  delete process.env.HONCHO_PROFILE;
+  delete process.env.HONCHO_API_KEY;
+});
+
+afterEach(() => {
+  if (ORIG_PROFILE !== undefined) process.env.HONCHO_PROFILE = ORIG_PROFILE;
+  if (ORIG_API_KEY !== undefined) process.env.HONCHO_API_KEY = ORIG_API_KEY;
+});
+
+const baseRaw: HonchoFileConfig = {
+  apiKey: "test-key",
+  peerName: "tester",
+  hosts: {
+    claude_code: { workspace: "hermes", aiPeer: "coder" },
+    "claude_code.director": { workspace: "7stars", aiPeer: "director" },
+  },
+};
+
+describe("resolveConfig — profile-aware host block lookup", () => {
+  test("HONCHO_PROFILE unset → returns bare claude_code block", () => {
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("hermes");
+    expect(config!.aiPeer).toBe("coder");
+    expect(config!.profile).toBeUndefined();
+  });
+});

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { resolveConfig, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
@@ -39,5 +39,23 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.workspace).toBe("7stars");
     expect(config!.aiPeer).toBe("director");
     expect(config!.profile).toBe("director");
+  });
+
+  test("HONCHO_PROFILE=ghost + no matching block → bare block + stderr warn", () => {
+    process.env.HONCHO_PROFILE = "ghost";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      const config = resolveConfig(baseRaw, "claude_code");
+      expect(config).not.toBeNull();
+      expect(config!.workspace).toBe("hermes");
+      expect(config!.aiPeer).toBe("coder");
+      expect(config!.profile).toBe("ghost");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg =>
+        msg.includes("HONCHO_PROFILE=ghost") && msg.includes("missing")
+      )).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, type HonchoFileConfig } from "./config";
-import { warnIfProfileRoutedSave } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -123,6 +122,18 @@ describe("warnIfProfileRoutedSave — profile-routed write guard", () => {
 
   test("HONCHO_PROFILE empty string → no stderr output", () => {
     process.env.HONCHO_PROFILE = "";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE whitespace only → no stderr output (matches resolveConfig)", () => {
+    process.env.HONCHO_PROFILE = "   ";
     const stderrSpy = spyOn(process.stderr, "write");
     try {
       warnIfProfileRoutedSave("claude_code");

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -155,7 +155,7 @@ export async function initHook(): Promise<void> {
 // ============================================
 
 /** Raw shape of ~/.honcho/config.json on disk */
-interface HonchoFileConfig {
+export interface HonchoFileConfig {
   apiKey?: string;
   peerName?: string;
   workspace?: string;
@@ -278,7 +278,7 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
   return loadConfigFromEnv(resolvedHost);
 }
 
-function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
+export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
   const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
   if (!apiKey) return null;
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -470,7 +470,7 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
  * etc.) so the silent divergence is visible.
  */
 export function warnIfProfileRoutedSave(host: HonchoHost): void {
-  if (process.env.HONCHO_PROFILE) {
+  if (process.env.HONCHO_PROFILE?.trim()) {
     process.stderr.write(
       `[honcho] saveConfig() writing to bare hosts.${host} while ` +
       `HONCHO_PROFILE=${process.env.HONCHO_PROFILE} — profile blocks ` +

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -282,6 +282,17 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
   return loadConfigFromEnv(resolvedHost);
 }
 
+// Module-scoped dedupe for the missing-profile stderr warning. Lifetime
+// matches the hook process (one Claude Code hook invocation = one process),
+// so the Set effectively warns once per (host, profile) per hook firing.
+const _warnedMissingProfile = new Set<string>();
+
+// Test-only: drop the dedupe cache between assertions that exercise the
+// warning path. Not part of the public API; underscore-prefixed by convention.
+export function _resetProfileWarnCacheForTests(): void {
+  _warnedMissingProfile.clear();
+}
+
 export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
   const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
   if (!apiKey) return null;
@@ -311,11 +322,11 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   // on the full `${host}.${profile}` string would also rewrite the
   // profile (e.g. `director-7stars` → `director_7stars`), pointing at
   // a different profile.
-  const hostAliases = [
+  const hostAliases = Array.from(new Set([
     host,
     host.replace(/_/g, "-"),
     host.replace(/-/g, "_"),
-  ];
+  ]));
 
   let hostBlock: HostConfig | undefined;
   let profileMatched = false;
@@ -343,9 +354,16 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   if (profile && !profileMatched) {
     // Profile requested but no matching block — log and fall back.
     // Logger may not be initialized in early hooks; use stderr directly.
-    process.stderr.write(
-      `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
-    );
+    // Dedupe per (host, profile) per process: loadConfig() is called from
+    // many helpers per hook invocation, so a naive write produces N
+    // duplicate lines that drown real diagnostics.
+    const warnKey = `${host}.${profile}`;
+    if (!_warnedMissingProfile.has(warnKey)) {
+      _warnedMissingProfile.add(warnKey);
+      process.stderr.write(
+        `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
+      );
+    }
   }
 
   if (raw.globalOverride === true) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -228,6 +228,10 @@ export interface HonchoCLAUDEConfig {
   logging?: boolean;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+  /** Active honcho profile from HONCHO_PROFILE env var, or undefined when
+   *  unset. Useful for diagnostics; the host-block lookup already factors
+   *  this in. */
+  profile?: string;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -288,9 +292,61 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   let workspace: string;
   let aiPeer: string;
 
-  const hostBlock = raw.hosts?.[host]
-    ?? raw.hosts?.[host.replace(/_/g, "-")]
-    ?? raw.hosts?.[host.replace(/-/g, "_")];
+  // Profile-aware host block lookup. HONCHO_PROFILE env var (set by `cl`
+  // wrapper or caller) selects a profile-suffixed block; falls back to
+  // bare host block when profile unset, missing, or empty after
+  // sanitization.
+  //
+  // Sanitization uses replace-with-`-` (matching `cl`'s `tr -c ... '-'`)
+  // so direct env settings like HONCHO_PROFILE=director.7stars yield the
+  // same lookup key (`director-7stars`) regardless of whether `cl`
+  // exported it or the user set it inline.
+  const profile = (process.env.HONCHO_PROFILE ?? "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  // Alias the HOST PORTION only ("claude_code" ↔ "claude-code"). The
+  // profile suffix must stay byte-exact — a blanket `replace(/-/g, "_")`
+  // on the full `${host}.${profile}` string would also rewrite the
+  // profile (e.g. `director-7stars` → `director_7stars`), pointing at
+  // a different profile.
+  const hostAliases = [
+    host,
+    host.replace(/_/g, "-"),
+    host.replace(/-/g, "_"),
+  ];
+
+  let hostBlock: HostConfig | undefined;
+  let profileMatched = false;
+
+  if (profile) {
+    for (const h of hostAliases) {
+      const key = `${h}.${profile}`;
+      if (raw.hosts?.[key]) {
+        hostBlock = raw.hosts[key];
+        profileMatched = true;
+        break;
+      }
+    }
+  }
+
+  if (!hostBlock) {
+    for (const h of hostAliases) {
+      if (raw.hosts?.[h]) {
+        hostBlock = raw.hosts[h];
+        break;
+      }
+    }
+  }
+
+  if (profile && !profileMatched) {
+    // Profile requested but no matching block — log and fall back.
+    // Logger may not be initialized in early hooks; use stderr directly.
+    process.stderr.write(
+      `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
+    );
+  }
 
   if (raw.globalOverride === true) {
     // Global override: flat fields apply to ALL hosts
@@ -334,6 +390,7 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
+    profile: profile || undefined,
   };
 
   return mergeWithEnvVars(config);

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -462,6 +462,25 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
 }
 
 /**
+ * Emit a stderr warning when saveConfig is called while HONCHO_PROFILE
+ * is set. Profile-routed sessions read from hosts.<host>.<profile> but
+ * saveConfig always writes to the bare hosts.<host> block — profile
+ * blocks are hand-curated, not runtime-mutable. Fires for any saveConfig
+ * caller (set_config, setSessionForPath, setPluginEnabled, setEndpoint,
+ * etc.) so the silent divergence is visible.
+ */
+export function warnIfProfileRoutedSave(host: HonchoHost): void {
+  if (process.env.HONCHO_PROFILE) {
+    process.stderr.write(
+      `[honcho] saveConfig() writing to bare hosts.${host} while ` +
+      `HONCHO_PROFILE=${process.env.HONCHO_PROFILE} — profile blocks ` +
+      `are hand-curated; edit ~/.honcho/config.json directly to change ` +
+      `the profile block.\n`
+    );
+  }
+}
+
+/**
  * Write-back: read-merge-write to avoid clobbering other hosts' config.
  *
  * Convention:
@@ -498,6 +517,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   // Keep workspace/aiPeer host-local, but avoid materializing root defaults
   // into new host overrides. This preserves root fallback behavior.
   const host = getDetectedHost();
+  warnIfProfileRoutedSave(host);
   if (!existing.hosts) existing.hosts = {};
   const existingHost: HostConfig = existing.hosts[host] ?? {};
 

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -112,6 +112,7 @@ function handleGetConfig(cwd: string) {
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
+    profile: cfg.profile,
   } : null;
 
   // Current status header values
@@ -195,6 +196,7 @@ function handleGetConfig(cwd: string) {
     ["session", sessionName ?? "unknown"],
     ["mapping", strategyLabels[cfg.sessionStrategy ?? "per-directory"] ?? cfg.sessionStrategy ?? "per directory"],
     ["peer", `${cfg.peerName} / ${cfg.aiPeer}`],
+    ...(cfg.profile ? [["profile", cfg.profile] as [string, string]] : []),
     ["host", hostLabel],
     ["messages", cfg.saveMessages !== false ? "saving enabled" : "saving disabled"],
     ["obs mode", cfg.observationMode ?? "unified"],
@@ -477,6 +479,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
+    profile: cfg.profile,
   };
 
   // Warn about stale sessions when changing fields that affect session routing


### PR DESCRIPTION
## Summary

Adds support for a `HONCHO_PROFILE` environment variable that selects a profile-suffixed host block (`hosts.<host>.<profile>`, e.g. `hosts.claude_code.director`) at config-resolve time. Falls back to the bare host block when unset, missing, or empty after sanitization.

Cross-tool generality: any host (`claude_code`, `cursor`, `obsidian`) supports profile suffixing, so the mechanism isn't claude-code-specific. Useful for users routing different projects to different Honcho identities — set the env var via a wrapper script or directly in the parent shell.

## Why

Without this, every Claude Code session writes to the same Honcho identity regardless of which project the cwd is in. Adding `HONCHO_PROFILE` lets a thin wrapper (or the user) declare the active profile per-session, and the resolver picks the matching host block. Each profile gets its own `aiPeer` + observation settings — full identity isolation while keeping a single `workspace` for cross-machine memory unification.

## What's in the patch

1. **Profile-aware host block lookup** in `resolveConfig`. Sanitizes the env var (`[^a-zA-Z0-9_-]` → `-`, matching the existing session-name sanitization rule), aliases the **host portion only** (`claude_code` ↔ `claude-code`, profile suffix kept byte-exact to avoid `director-7stars` collapsing to `director_7stars` via blanket replace), and looks up `hosts.<host>.<profile>` before falling back to bare.

2. **`profile` field on `HonchoCLAUDEConfig`** so MCP `get_config` and other diagnostics surface the active profile name.

3. **`saveConfig` stderr guard** — when `HONCHO_PROFILE` is set, `saveConfig` still writes to the bare host block (profile blocks are hand-curated, not runtime-mutable), but emits a stderr warning so the silent divergence is visible. Implemented as an extracted `warnIfProfileRoutedSave` helper for testability — `CONFIG_FILE` is captured at module-load via `homedir()`, so an inline check inside `saveConfig` would force tests to either touch the real `~/.honcho/config.json` or do invasive module-level filesystem mocking. The helper exports cleanly and the implementation is otherwise unchanged. Happy to inline it back if maintainers prefer.

4. Minor: `resolveConfig` and `HonchoFileConfig` are now exported (previously module-private) to enable direct unit testing without filesystem mocking.

## Config example

After the patch, `~/.honcho/config.json` supports profile-suffixed blocks alongside the bare host block. Each block must carry **explicit `workspace` and `aiPeer`** — those two fields fall back to `DEFAULT_<X>[host]` rather than root-level config (see the closing note for context).

```json
{
  "apiKey": "...",
  "peerName": "alice",
  "endpoint": { "baseUrl": "..." },
  "observationMode": "directional",
  "sessionPeerPrefix": false,
  "hosts": {
    "claude_code": {
      "workspace": "shared",
      "aiPeer": "default"
    },
    "claude_code.coder": {
      "workspace": "shared",
      "aiPeer": "coder"
    },
    "claude_code.director": {
      "workspace": "shared",
      "aiPeer": "director"
    }
  }
}
```

Run-time selection:

```bash
# No env -> bare claude_code block (workspace=shared, aiPeer=default)
claude

# Routes to claude_code.coder block (workspace=shared, aiPeer=coder)
HONCHO_PROFILE=coder claude

# Routes to claude_code.director block
HONCHO_PROFILE=director claude

# No matching block -> stderr warning + bare fallback
HONCHO_PROFILE=ghost claude
```

MCP `get_config` returns the resolved values plus the new `profile` field:

```json
{
  "workspace": "shared",
  "aiPeer": "director",
  "profile": "director",
  "observationMode": "directional",
  "sessionPeerPrefix": false
}
```

**Cross-machine memory unification.** Same `workspace` across blocks means if another tool (a different host like `cursor`, or another machine running an external client that writes to the same Honcho instance) also writes with `aiPeer=director`, both clients' `director` peer accumulate context together — a single identity across multiple surfaces. Different workspace per profile is supported but splits memory; choose deliberately.

## Out of scope

- `saveConfig` writes still target the bare host block. Making MCP-driven mutations target the active profile block would be a separate, larger change and changes the "profile blocks are hand-curated" invariant.
- No CLI command to manage profile blocks — they're edited in `~/.honcho/config.json` directly.

## Test plan

- [x] 9 unit tests in `plugins/honcho/src/config.test.ts` covering: profile env unset → bare; profile env set + matching block → profile resolution; missing block → bare fallback + stderr warn; illegal-char sanitization; alias-collision regression (profile suffix preservation); 3 `warnIfProfileRoutedSave` tests (set / unset / empty / whitespace). All pass via `bun test src/config.test.ts`.
- [x] Local install via `scripts/install-local.sh` + Claude Code restart, manual MCP `get_config` verification — confirms profile routing fires when `HONCHO_PROFILE` is set, missing-block warning fires when no match, bare block resolves cleanly when env unset.
- [x] CHANGELOG.md entry added.

## Notes

- Added an `asymmetric fallback` observation to my downstream design doc: `workspace` and `aiPeer` fall back to `DEFAULT_<X>[host]` (host name doubling as default) rather than `raw.X`. This caught me by surprise when minimal profile blocks silently routed data to `workspace=claude_code`. Behavior is correct (host-scoped identity), but worth a maintainer's eye if you'd consider documenting it in the README's host config section — the config example above shows the workaround (explicit `workspace` per block).
