### PR TITLE
feat(config): HONCHO_SESSION env var for per-launch session pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `HONCHO_PROFILE` environment variable enables per-session identity routing. When set, `resolveConfig` looks up a profile-suffixed host block (`hosts.<host>.<profile>`, e.g. `hosts.claude_code.director`) before falling back to the bare host block. The new `profile` field on `HonchoCLAUDEConfig` surfaces the active value for diagnostics (e.g. via MCP `get_config`). Setting `HONCHO_PROFILE` during a `saveConfig` call emits a stderr warning since writes always target the bare block; profile blocks are hand-curated.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to claude-honcho will be documented in this file.
 
 ### Added
 
+- `HONCHO_SESSION` environment variable pins the Honcho session name for the launch. When set and non-empty after sanitization (`[^a-zA-Z0-9_-]+ → -`, edge-strip), `getSessionName` returns the sanitized value, bypassing the manual `sessions[cwd]` map and strategy switch. The new `session` and `sessionSource` fields on `HonchoCLAUDEConfig` surface the active value for diagnostics (e.g. via MCP `get_config`). Setting `HONCHO_SESSION` while calling `setSessionForPath` emits a stderr warning since the env var routes session reads past `sessions[cwd]`, leaving the new entry dormant.
 - `HONCHO_PROFILE` environment variable enables per-session identity routing. When set, `resolveConfig` looks up a profile-suffixed host block (`hosts.<host>.<profile>`, e.g. `hosts.claude_code.director`) before falling back to the bare host block. The new `profile` field on `HonchoCLAUDEConfig` surfaces the active value for diagnostics (e.g. via MCP `get_config`). Setting `HONCHO_PROFILE` during a `saveConfig` call emits a stderr warning since writes always target the bare block; profile blocks are hand-curated.
 
 ## [0.2.4] - 2026-04-01

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
 | `HONCHO_PROFILE`       | No       | unset         | Selects `hosts.<host>.<profile>` block; falls back to bare `hosts.<host>` when unset or no match (with stderr warning). Useful for routing different projects to different identities. |
+| `HONCHO_SESSION`       | No       | unset         | Pin the Honcho session name for this launch. Sanitized to `[a-zA-Z0-9_-]`. Highest-priority override — wins over manual `sessions[cwd]` entries and strategy derivation. Empty/whitespace falls through to existing logic. |
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
+| `HONCHO_PROFILE`       | No       | unset         | Selects `hosts.<host>.<profile>` block; falls back to bare `hosts.<host>` when unset or no match (with stderr warning). Useful for routing different projects to different identities. |
 
 ## How It Works
 

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -74,4 +74,20 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.aiPeer).toBe("director-7stars");
     expect(config!.profile).toBe("director-7stars");
   });
+
+  test("profile suffix with hyphens not corrupted by alias chain", () => {
+    process.env.HONCHO_PROFILE = "director-7stars";
+    const rawAmbiguous: HonchoFileConfig = {
+      ...baseRaw,
+      hosts: {
+        ...baseRaw.hosts,
+        "claude_code.director-7stars": { workspace: "7stars-dash",  aiPeer: "director-dash"  },
+        "claude_code.director_7stars": { workspace: "7stars-under", aiPeer: "director-under" },
+      },
+    };
+    const config = resolveConfig(rawAmbiguous, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars-dash");
+    expect(config!.aiPeer).toBe("director-dash");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -330,3 +330,42 @@ describe("setSessionForPath — HONCHO_SESSION write guard", () => {
     }
   });
 });
+
+describe("resolveConfig — HONCHO_SESSION diagnostic surface", () => {
+  beforeEach(() => {
+    delete process.env.HONCHO_SESSION;
+  });
+
+  afterEach(() => {
+    if (ORIG_HONCHO_SESSION !== undefined) process.env.HONCHO_SESSION = ORIG_HONCHO_SESSION;
+    else delete process.env.HONCHO_SESSION;
+  });
+
+  test("HONCHO_SESSION=foo → config.session='foo', sessionSource='env'", () => {
+    process.env.HONCHO_SESSION = "foo";
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config?.session).toBe("foo");
+    expect(config?.sessionSource).toBe("env");
+  });
+
+  test("HONCHO_SESSION=Foo.Bar! → sanitized + casing preserved", () => {
+    process.env.HONCHO_SESSION = "Foo.Bar!";
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config?.session).toBe("Foo-Bar");
+    expect(config?.sessionSource).toBe("env");
+  });
+
+  test("HONCHO_SESSION unset → session and sessionSource both undefined", () => {
+    delete process.env.HONCHO_SESSION;
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config?.session).toBeUndefined();
+    expect(config?.sessionSource).toBeUndefined();
+  });
+
+  test("HONCHO_SESSION=--- → sanitizes to empty → both undefined", () => {
+    process.env.HONCHO_SESSION = "---";
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config?.session).toBeUndefined();
+    expect(config?.sessionSource).toBeUndefined();
+  });
+});

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, getSessionName, type HonchoFileConfig } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, getSessionName, type HonchoFileConfig, type HonchoCLAUDEConfig } from "./config";
+import * as configModule from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -223,5 +224,41 @@ describe("getSessionName — HONCHO_SESSION env var", () => {
     // didn't intercept (returned a non-empty value derived from cwd or strategy).
     expect(typeof result).toBe("string");
     expect(result.length).toBeGreaterThan(0);
+  });
+
+  test("HONCHO_SESSION=foo overrides manual sessions[cwd] entry", () => {
+    process.env.HONCHO_SESSION = "foo";
+    const loadConfigSpy = spyOn(configModule, "loadConfig").mockReturnValue({
+      apiKey: "test",
+      peerName: "tester",
+      workspace: "test-ws",
+      aiPeer: "tester",
+      sessionStrategy: "per-directory",
+      sessionPeerPrefix: false,
+      sessions: { "/tmp/myproj": "from-manual-map" },
+    } as HonchoCLAUDEConfig);
+    try {
+      expect(getSessionName("/tmp/myproj")).toBe("foo");
+    } finally {
+      loadConfigSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_SESSION unset → manual sessions[cwd] still wins under per-directory", () => {
+    delete process.env.HONCHO_SESSION;
+    const loadConfigSpy = spyOn(configModule, "loadConfig").mockReturnValue({
+      apiKey: "test",
+      peerName: "tester",
+      workspace: "test-ws",
+      aiPeer: "tester",
+      sessionStrategy: "per-directory",
+      sessionPeerPrefix: false,
+      sessions: { "/tmp/myproj": "from-manual-map" },
+    } as HonchoCLAUDEConfig);
+    try {
+      expect(getSessionName("/tmp/myproj")).toBe("from-manual-map");
+    } finally {
+      loadConfigSpy.mockRestore();
+    }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, type HonchoFileConfig } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, getSessionName, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -175,5 +175,53 @@ describe("warnIfProfileRoutedSave — profile-routed write guard", () => {
     } finally {
       stderrSpy.mockRestore();
     }
+  });
+});
+
+const ORIG_HONCHO_SESSION = process.env.HONCHO_SESSION;
+
+describe("getSessionName — HONCHO_SESSION env var", () => {
+  beforeEach(() => {
+    delete process.env.HONCHO_SESSION;
+  });
+
+  afterEach(() => {
+    if (ORIG_HONCHO_SESSION !== undefined) process.env.HONCHO_SESSION = ORIG_HONCHO_SESSION;
+    else delete process.env.HONCHO_SESSION;
+  });
+
+  test("HONCHO_SESSION=foo → returns 'foo' (skips loadConfig path)", () => {
+    process.env.HONCHO_SESSION = "foo";
+    expect(getSessionName("/tmp/anything")).toBe("foo");
+  });
+
+  test("HONCHO_SESSION=Foo.Bar! → sanitized to 'Foo-Bar' (case preserved)", () => {
+    process.env.HONCHO_SESSION = "Foo.Bar!";
+    expect(getSessionName("/tmp/anything")).toBe("Foo-Bar");
+  });
+
+  test("HONCHO_SESSION=--- → sanitizes to empty → falls through (no env-derived name)", () => {
+    process.env.HONCHO_SESSION = "---";
+    const result = getSessionName("/tmp/somedir");
+    // Falls through to existing logic. We assert only that the env-var path
+    // didn't return the literal "---" or empty string.
+    expect(result).not.toBe("---");
+    expect(result).not.toBe("");
+  });
+
+  test("HONCHO_SESSION='   ' (whitespace) → falls through", () => {
+    process.env.HONCHO_SESSION = "   ";
+    const result = getSessionName("/tmp/somedir");
+    expect(result).not.toBe("   ");
+    expect(result).not.toBe("");
+  });
+
+  test("HONCHO_SESSION unset → falls through to existing logic", () => {
+    delete process.env.HONCHO_SESSION;
+    const result = getSessionName("/tmp/somedir");
+    // Existing logic depends on disk config; we just check the env-var path
+    // didn't intercept (returned a non-empty value derived from cwd or strategy).
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, getSessionName, type HonchoFileConfig, type HonchoCLAUDEConfig } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, getSessionName, setSessionForPath, type HonchoFileConfig, type HonchoCLAUDEConfig } from "./config";
 import * as configModule from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
@@ -259,6 +259,74 @@ describe("getSessionName — HONCHO_SESSION env var", () => {
       expect(getSessionName("/tmp/myproj")).toBe("from-manual-map");
     } finally {
       loadConfigSpy.mockRestore();
+    }
+  });
+});
+
+describe("setSessionForPath — HONCHO_SESSION write guard", () => {
+  beforeEach(() => {
+    delete process.env.HONCHO_SESSION;
+  });
+
+  afterEach(() => {
+    if (ORIG_HONCHO_SESSION !== undefined) process.env.HONCHO_SESSION = ORIG_HONCHO_SESSION;
+    else delete process.env.HONCHO_SESSION;
+  });
+
+  test("HONCHO_SESSION set → setSessionForPath emits stderr warning", () => {
+    process.env.HONCHO_SESSION = "active-pin";
+    const stderrSpy = spyOn(process.stderr, "write");
+    const saveSpy = spyOn(configModule, "saveConfig").mockImplementation(() => {});
+    const loadSpy = spyOn(configModule, "loadConfig").mockReturnValue({
+      apiKey: "k", peerName: "p", workspace: "w", aiPeer: "a",
+    });
+    try {
+      setSessionForPath("/tmp/x", "manual-name");
+      const calls = stderrSpy.mock.calls.map(c => String(c[0]));
+      expect(calls.some(msg =>
+        msg.includes("HONCHO_SESSION=active-pin") &&
+        msg.includes("setSessionForPath")
+      )).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+      saveSpy.mockRestore();
+      loadSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_SESSION unset → no warning", () => {
+    delete process.env.HONCHO_SESSION;
+    const stderrSpy = spyOn(process.stderr, "write");
+    const saveSpy = spyOn(configModule, "saveConfig").mockImplementation(() => {});
+    const loadSpy = spyOn(configModule, "loadConfig").mockReturnValue({
+      apiKey: "k", peerName: "p", workspace: "w", aiPeer: "a",
+    });
+    try {
+      setSessionForPath("/tmp/x", "manual-name");
+      const calls = stderrSpy.mock.calls.map(c => String(c[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_SESSION"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+      saveSpy.mockRestore();
+      loadSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_SESSION whitespace-only → no warning", () => {
+    process.env.HONCHO_SESSION = "   ";
+    const stderrSpy = spyOn(process.stderr, "write");
+    const saveSpy = spyOn(configModule, "saveConfig").mockImplementation(() => {});
+    const loadSpy = spyOn(configModule, "loadConfig").mockReturnValue({
+      apiKey: "k", peerName: "p", workspace: "w", aiPeer: "a",
+    });
+    try {
+      setSessionForPath("/tmp/x", "manual-name");
+      const calls = stderrSpy.mock.calls.map(c => String(c[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_SESSION"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+      saveSpy.mockRestore();
+      loadSpy.mockRestore();
     }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, warnIfProfileRoutedSave, type HonchoFileConfig } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, _resetProfileWarnCacheForTests, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -7,6 +7,7 @@ const ORIG_API_KEY = process.env.HONCHO_API_KEY;
 beforeEach(() => {
   delete process.env.HONCHO_PROFILE;
   delete process.env.HONCHO_API_KEY;
+  _resetProfileWarnCacheForTests();
 });
 
 afterEach(() => {
@@ -73,6 +74,38 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.workspace).toBe("7stars");
     expect(config!.aiPeer).toBe("director-7stars");
     expect(config!.profile).toBe("director-7stars");
+  });
+
+  test("HONCHO_PROFILE sanitizing to empty → bare block, no warning", () => {
+    process.env.HONCHO_PROFILE = "...";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      const config = resolveConfig(baseRaw, "claude_code");
+      expect(config).not.toBeNull();
+      expect(config!.workspace).toBe("hermes");
+      expect(config!.aiPeer).toBe("coder");
+      expect(config!.profile).toBeUndefined();
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("missing-profile warning dedupes across multiple resolveConfig calls", () => {
+    process.env.HONCHO_PROFILE = "ghost";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      resolveConfig(baseRaw, "claude_code");
+      resolveConfig(baseRaw, "claude_code");
+      resolveConfig(baseRaw, "claude_code");
+      const matching = stderrSpy.mock.calls
+        .map(call => String(call[0]))
+        .filter(msg => msg.includes("HONCHO_PROFILE=ghost"));
+      expect(matching.length).toBe(1);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 
   test("profile suffix with hyphens not corrupted by alias chain", () => {

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -31,4 +31,13 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.aiPeer).toBe("coder");
     expect(config!.profile).toBeUndefined();
   });
+
+  test("HONCHO_PROFILE=director + matching block → returns profile block", () => {
+    process.env.HONCHO_PROFILE = "director";
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars");
+    expect(config!.aiPeer).toBe("director");
+    expect(config!.profile).toBe("director");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { resolveConfig, type HonchoFileConfig } from "./config";
+import { warnIfProfileRoutedSave } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -89,5 +90,46 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config).not.toBeNull();
     expect(config!.workspace).toBe("7stars-dash");
     expect(config!.aiPeer).toBe("director-dash");
+  });
+});
+
+describe("warnIfProfileRoutedSave — profile-routed write guard", () => {
+  test("HONCHO_PROFILE set → writes warning to stderr", () => {
+    process.env.HONCHO_PROFILE = "director";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg =>
+        msg.includes("HONCHO_PROFILE=director") &&
+        msg.includes("hand-curated")
+      )).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE unset → no stderr output", () => {
+    delete process.env.HONCHO_PROFILE;
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE empty string → no stderr output", () => {
+    process.env.HONCHO_PROFILE = "";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -58,4 +58,20 @@ describe("resolveConfig — profile-aware host block lookup", () => {
       stderrSpy.mockRestore();
     }
   });
+
+  test("HONCHO_PROFILE with illegal chars → sanitized to dash, matches sanitized block", () => {
+    process.env.HONCHO_PROFILE = "director.7stars";
+    const rawWithSanitizedBlock: HonchoFileConfig = {
+      ...baseRaw,
+      hosts: {
+        ...baseRaw.hosts,
+        "claude_code.director-7stars": { workspace: "7stars", aiPeer: "director-7stars" },
+      },
+    };
+    const config = resolveConfig(rawWithSanitizedBlock, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("7stars");
+    expect(config!.aiPeer).toBe("director-7stars");
+    expect(config!.profile).toBe("director-7stars");
+  });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { resolveConfig, type HonchoFileConfig } from "./config";
+
+const ORIG_PROFILE = process.env.HONCHO_PROFILE;
+const ORIG_API_KEY = process.env.HONCHO_API_KEY;
+
+beforeEach(() => {
+  delete process.env.HONCHO_PROFILE;
+  delete process.env.HONCHO_API_KEY;
+});
+
+afterEach(() => {
+  if (ORIG_PROFILE !== undefined) process.env.HONCHO_PROFILE = ORIG_PROFILE;
+  if (ORIG_API_KEY !== undefined) process.env.HONCHO_API_KEY = ORIG_API_KEY;
+});
+
+const baseRaw: HonchoFileConfig = {
+  apiKey: "test-key",
+  peerName: "tester",
+  hosts: {
+    claude_code: { workspace: "hermes", aiPeer: "coder" },
+    "claude_code.director": { workspace: "7stars", aiPeer: "director" },
+  },
+};
+
+describe("resolveConfig — profile-aware host block lookup", () => {
+  test("HONCHO_PROFILE unset → returns bare claude_code block", () => {
+    const config = resolveConfig(baseRaw, "claude_code");
+    expect(config).not.toBeNull();
+    expect(config!.workspace).toBe("hermes");
+    expect(config!.aiPeer).toBe("coder");
+    expect(config!.profile).toBeUndefined();
+  });
+});

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { resolveConfig, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
@@ -39,5 +39,23 @@ describe("resolveConfig — profile-aware host block lookup", () => {
     expect(config!.workspace).toBe("7stars");
     expect(config!.aiPeer).toBe("director");
     expect(config!.profile).toBe("director");
+  });
+
+  test("HONCHO_PROFILE=ghost + no matching block → bare block + stderr warn", () => {
+    process.env.HONCHO_PROFILE = "ghost";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      const config = resolveConfig(baseRaw, "claude_code");
+      expect(config).not.toBeNull();
+      expect(config!.workspace).toBe("hermes");
+      expect(config!.aiPeer).toBe("coder");
+      expect(config!.profile).toBe("ghost");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg =>
+        msg.includes("HONCHO_PROFILE=ghost") && msg.includes("missing")
+      )).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
   });
 });

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,6 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { resolveConfig, type HonchoFileConfig } from "./config";
-import { warnIfProfileRoutedSave } from "./config";
+import { resolveConfig, warnIfProfileRoutedSave, type HonchoFileConfig } from "./config";
 
 const ORIG_PROFILE = process.env.HONCHO_PROFILE;
 const ORIG_API_KEY = process.env.HONCHO_API_KEY;
@@ -123,6 +122,18 @@ describe("warnIfProfileRoutedSave — profile-routed write guard", () => {
 
   test("HONCHO_PROFILE empty string → no stderr output", () => {
     process.env.HONCHO_PROFILE = "";
+    const stderrSpy = spyOn(process.stderr, "write");
+    try {
+      warnIfProfileRoutedSave("claude_code");
+      const calls = stderrSpy.mock.calls.map(call => String(call[0]));
+      expect(calls.some(msg => msg.includes("HONCHO_PROFILE"))).toBe(false);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("HONCHO_PROFILE whitespace only → no stderr output (matches resolveConfig)", () => {
+    process.env.HONCHO_PROFILE = "   ";
     const stderrSpy = spyOn(process.stderr, "write");
     try {
       warnIfProfileRoutedSave("claude_code");

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -629,6 +629,14 @@ export function getSessionForPath(cwd: string): string | null {
  *                      when available to avoid cross-session collision from the global cache.
  */
 export function getSessionName(cwd: string, instanceId?: string): string {
+  // Env var override — highest priority, mirrors HONCHO_PROFILE pattern.
+  // Sits above the manual sessions[cwd] map and the strategy switch so an
+  // operator can pin the session at launch without editing config.json.
+  const envSession = (process.env.HONCHO_SESSION ?? "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (envSession) return envSession;
+
   const config = loadConfig();
   const strategy = config?.sessionStrategy ?? "per-directory";
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -678,6 +678,24 @@ export function getSessionName(cwd: string, instanceId?: string): string {
 }
 
 export function setSessionForPath(cwd: string, sessionName: string): void {
+  // Warn at this writer (not at saveConfig) so HONCHO_SESSION's silent
+  // shadowing of sessions[cwd] is visible without false-positives from
+  // setEndpoint, setPluginEnabled, setMessageUploadConfig, etc. — those
+  // call saveConfig but don't touch the sessions field, so they are
+  // unaffected by the env var. DO NOT move this warning to saveConfig.
+  // (warnIfProfileRoutedSave at config.ts:490 lives at saveConfig because
+  // the entire host block is profile-routed; HONCHO_SESSION's narrower
+  // scope warrants a narrower placement.)
+  const envPin = (process.env.HONCHO_SESSION ?? "").trim();
+  if (envPin) {
+    process.stderr.write(
+      `[honcho] setSessionForPath(${cwd}=${sessionName}) while ` +
+      `HONCHO_SESSION=${process.env.HONCHO_SESSION} — env var routes ` +
+      `session reads past sessions[cwd]; this entry is dormant until ` +
+      `HONCHO_SESSION is unset.\n`
+    );
+  }
+
   const config = loadConfig();
   if (!config) return;
   if (!config.sessions) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -155,7 +155,7 @@ export async function initHook(): Promise<void> {
 // ============================================
 
 /** Raw shape of ~/.honcho/config.json on disk */
-interface HonchoFileConfig {
+export interface HonchoFileConfig {
   apiKey?: string;
   peerName?: string;
   workspace?: string;
@@ -278,7 +278,7 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
   return loadConfigFromEnv(resolvedHost);
 }
 
-function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
+export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
   const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
   if (!apiKey) return null;
 

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -470,7 +470,7 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
  * etc.) so the silent divergence is visible.
  */
 export function warnIfProfileRoutedSave(host: HonchoHost): void {
-  if (process.env.HONCHO_PROFILE) {
+  if (process.env.HONCHO_PROFILE?.trim()) {
     process.stderr.write(
       `[honcho] saveConfig() writing to bare hosts.${host} while ` +
       `HONCHO_PROFILE=${process.env.HONCHO_PROFILE} — profile blocks ` +

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -282,6 +282,17 @@ export function loadConfig(host?: HonchoHost): HonchoCLAUDEConfig | null {
   return loadConfigFromEnv(resolvedHost);
 }
 
+// Module-scoped dedupe for the missing-profile stderr warning. Lifetime
+// matches the hook process (one Claude Code hook invocation = one process),
+// so the Set effectively warns once per (host, profile) per hook firing.
+const _warnedMissingProfile = new Set<string>();
+
+// Test-only: drop the dedupe cache between assertions that exercise the
+// warning path. Not part of the public API; underscore-prefixed by convention.
+export function _resetProfileWarnCacheForTests(): void {
+  _warnedMissingProfile.clear();
+}
+
 export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDEConfig | null {
   const apiKey = process.env.HONCHO_API_KEY || raw.apiKey;
   if (!apiKey) return null;
@@ -311,11 +322,11 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   // on the full `${host}.${profile}` string would also rewrite the
   // profile (e.g. `director-7stars` → `director_7stars`), pointing at
   // a different profile.
-  const hostAliases = [
+  const hostAliases = Array.from(new Set([
     host,
     host.replace(/_/g, "-"),
     host.replace(/-/g, "_"),
-  ];
+  ]));
 
   let hostBlock: HostConfig | undefined;
   let profileMatched = false;
@@ -343,9 +354,16 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   if (profile && !profileMatched) {
     // Profile requested but no matching block — log and fall back.
     // Logger may not be initialized in early hooks; use stderr directly.
-    process.stderr.write(
-      `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
-    );
+    // Dedupe per (host, profile) per process: loadConfig() is called from
+    // many helpers per hook invocation, so a naive write produces N
+    // duplicate lines that drown real diagnostics.
+    const warnKey = `${host}.${profile}`;
+    if (!_warnedMissingProfile.has(warnKey)) {
+      _warnedMissingProfile.add(warnKey);
+      process.stderr.write(
+        `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
+      );
+    }
   }
 
   if (raw.globalOverride === true) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -228,6 +228,10 @@ export interface HonchoCLAUDEConfig {
   logging?: boolean;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+  /** Active honcho profile from HONCHO_PROFILE env var, or undefined when
+   *  unset. Useful for diagnostics; the host-block lookup already factors
+   *  this in. */
+  profile?: string;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -288,9 +292,61 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
   let workspace: string;
   let aiPeer: string;
 
-  const hostBlock = raw.hosts?.[host]
-    ?? raw.hosts?.[host.replace(/_/g, "-")]
-    ?? raw.hosts?.[host.replace(/-/g, "_")];
+  // Profile-aware host block lookup. HONCHO_PROFILE env var (set by `cl`
+  // wrapper or caller) selects a profile-suffixed block; falls back to
+  // bare host block when profile unset, missing, or empty after
+  // sanitization.
+  //
+  // Sanitization uses replace-with-`-` (matching `cl`'s `tr -c ... '-'`)
+  // so direct env settings like HONCHO_PROFILE=director.7stars yield the
+  // same lookup key (`director-7stars`) regardless of whether `cl`
+  // exported it or the user set it inline.
+  const profile = (process.env.HONCHO_PROFILE ?? "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  // Alias the HOST PORTION only ("claude_code" ↔ "claude-code"). The
+  // profile suffix must stay byte-exact — a blanket `replace(/-/g, "_")`
+  // on the full `${host}.${profile}` string would also rewrite the
+  // profile (e.g. `director-7stars` → `director_7stars`), pointing at
+  // a different profile.
+  const hostAliases = [
+    host,
+    host.replace(/_/g, "-"),
+    host.replace(/-/g, "_"),
+  ];
+
+  let hostBlock: HostConfig | undefined;
+  let profileMatched = false;
+
+  if (profile) {
+    for (const h of hostAliases) {
+      const key = `${h}.${profile}`;
+      if (raw.hosts?.[key]) {
+        hostBlock = raw.hosts[key];
+        profileMatched = true;
+        break;
+      }
+    }
+  }
+
+  if (!hostBlock) {
+    for (const h of hostAliases) {
+      if (raw.hosts?.[h]) {
+        hostBlock = raw.hosts[h];
+        break;
+      }
+    }
+  }
+
+  if (profile && !profileMatched) {
+    // Profile requested but no matching block — log and fall back.
+    // Logger may not be initialized in early hooks; use stderr directly.
+    process.stderr.write(
+      `[honcho] HONCHO_PROFILE=${profile} but hosts.${host}.${profile} missing — using bare ${host}\n`
+    );
+  }
 
   if (raw.globalOverride === true) {
     // Global override: flat fields apply to ALL hosts
@@ -334,6 +390,7 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
+    profile: profile || undefined,
   };
 
   return mergeWithEnvVars(config);

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -232,6 +232,10 @@ export interface HonchoCLAUDEConfig {
    *  unset. Useful for diagnostics; the host-block lookup already factors
    *  this in. */
   profile?: string;
+  /** Resolved session pin from HONCHO_SESSION env var (sanitized). Undefined when env unset. */
+  session?: string;
+  /** Provenance of `session`. 'env' = HONCHO_SESSION-derived. Future: 'manual'/'computed' (deferred). */
+  sessionSource?: "env" | "manual" | "computed";
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -410,6 +414,14 @@ export function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCL
     globalOverride: raw.globalOverride,
     profile: profile || undefined,
   };
+
+  const sessionEnv = (process.env.HONCHO_SESSION ?? "")
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  if (sessionEnv) {
+    config.session = sessionEnv;
+    config.sessionSource = "env";
+  }
 
   return mergeWithEnvVars(config);
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -462,6 +462,25 @@ function mergeWithEnvVars(config: HonchoCLAUDEConfig): HonchoCLAUDEConfig {
 }
 
 /**
+ * Emit a stderr warning when saveConfig is called while HONCHO_PROFILE
+ * is set. Profile-routed sessions read from hosts.<host>.<profile> but
+ * saveConfig always writes to the bare hosts.<host> block — profile
+ * blocks are hand-curated, not runtime-mutable. Fires for any saveConfig
+ * caller (set_config, setSessionForPath, setPluginEnabled, setEndpoint,
+ * etc.) so the silent divergence is visible.
+ */
+export function warnIfProfileRoutedSave(host: HonchoHost): void {
+  if (process.env.HONCHO_PROFILE) {
+    process.stderr.write(
+      `[honcho] saveConfig() writing to bare hosts.${host} while ` +
+      `HONCHO_PROFILE=${process.env.HONCHO_PROFILE} — profile blocks ` +
+      `are hand-curated; edit ~/.honcho/config.json directly to change ` +
+      `the profile block.\n`
+    );
+  }
+}
+
+/**
  * Write-back: read-merge-write to avoid clobbering other hosts' config.
  *
  * Convention:
@@ -498,6 +517,7 @@ export function saveConfig(config: HonchoCLAUDEConfig): void {
   // Keep workspace/aiPeer host-local, but avoid materializing root defaults
   // into new host overrides. This preserves root fallback behavior.
   const host = getDetectedHost();
+  warnIfProfileRoutedSave(host);
   if (!existing.hosts) existing.hosts = {};
   const existingHost: HostConfig = existing.hosts[host] ?? {};
 

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -113,6 +113,8 @@ function handleGetConfig(cwd: string) {
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
     profile: cfg.profile,
+    session: cfg.session,
+    sessionSource: cfg.sessionSource,
   } : null;
 
   // Current status header values

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -112,6 +112,7 @@ function handleGetConfig(cwd: string) {
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
+    profile: cfg.profile,
   } : null;
 
   // Current status header values
@@ -195,6 +196,7 @@ function handleGetConfig(cwd: string) {
     ["session", sessionName ?? "unknown"],
     ["mapping", strategyLabels[cfg.sessionStrategy ?? "per-directory"] ?? cfg.sessionStrategy ?? "per directory"],
     ["peer", `${cfg.peerName} / ${cfg.aiPeer}`],
+    ...(cfg.profile ? [["profile", cfg.profile] as [string, string]] : []),
     ["host", hostLabel],
     ["messages", cfg.saveMessages !== false ? "saving enabled" : "saving disabled"],
     ["obs mode", cfg.observationMode ?? "unified"],
@@ -477,6 +479,7 @@ function handleSetConfig(args: Record<string, unknown>) {
     enabled: cfg.enabled !== false,
     logging: cfg.logging !== false,
     saveMessages: cfg.saveMessages !== false,
+    profile: cfg.profile,
   };
 
   // Warn about stale sessions when changing fields that affect session routing


### PR DESCRIPTION
## Summary

Adds a `HONCHO_SESSION` env var that pins the Honcho session name for the launch, mirroring the `HONCHO_PROFILE` env var added in #33. Operators can pin the session from a wrapper or shell without editing `~/.honcho/config.json`.

## Motivation

Today the only operator-controlled session-name surface is the manual `sessions[cwd]` map, hand-edited per CWD. A launch-time env var makes pinning composable: wrappers (e.g., a per-project shell wrapper in operator tooling) can read project metadata and export the env var without persisting state to the user's config.

## Changes

- `getSessionName(cwd, instanceId?)` reads `HONCHO_SESSION` at the top of the function. If non-empty after sanitization, the function returns the env value directly, bypassing the manual map and strategy switch.
- Sanitization: `[^a-zA-Z0-9_-]+ → -`, then strip leading/trailing dashes. Casing preserved (consistent with operator-written values like `HONCHO_PROFILE` and hermes-agent's `/title`).
- `setSessionForPath` emits a stderr notice when `HONCHO_SESSION` is set, since the env var diverts session reads past `config.sessions[cwd]`. Placed at the writer (not at `saveConfig`) so unrelated setters don't false-positive — the placement comment carries the invariant explicitly.
- `HonchoCLAUDEConfig` gains optional `session?: string` and `sessionSource?: 'env' | 'manual' | 'computed'` fields. `resolveConfig` populates them with `'env'` provenance (mirroring how it already populates `profile` from `HONCHO_PROFILE`); both stay `undefined` for non-env-derived sessions. `'manual'` and `'computed'` are reserved for a future PR (would require a cwd parameter on `resolveConfig`). `get_config` MCP returns both fields.
- README env var table + CHANGELOG entry.

## Tests

`plugins/honcho/src/config.test.ts` adds 14 tests across four describe blocks:

- `getSessionName — HONCHO_SESSION env var` (5 tests): env-set returns sanitized value, casing preserved, edge sanitization to empty falls through, whitespace falls through, env-unset preserves existing logic.
- `getSessionName — manual-map interaction` (2 tests): env wins over manual `sessions[cwd]`; manual map still wins when env is unset.
- `setSessionForPath — HONCHO_SESSION write guard` (3 tests): warning fires when env is set; no warning when unset; no warning on whitespace-only.
- `resolveConfig — HONCHO_SESSION diagnostic surface` (4 tests): env-set exposes `session` and `sessionSource: 'env'`; sanitization preserves casing; env-unset leaves both undefined; sanitize-to-empty leaves both undefined.

Run with `bun test plugins/honcho/src/config.test.ts`. All 25 tests pass; no regressions.

## Notes

Branched off `feature/honcho-profile-env` (#33). If #33 lands first, this PR's diff against `main` is clean. If #33 needs revisions, this PR rebases as-is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `HONCHO_SESSION` environment variable to explicitly pin session names with automatic fallback
  * Added `HONCHO_PROFILE` environment variable to select host-specific profile configuration blocks
  * New warnings when environment-pinned settings override manual configurations

* **Documentation**
  * Updated CHANGELOG and README describing new environment variable behavior

* **Tests**
  * Added comprehensive test coverage for profile and session configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->