### PR TITLE
feat(config): cwd-based workspaceRules routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to claude-honcho will be documented in this file.
 ### Added
 
 - `workspaceRules` config field — cwd-prefix-based workspace routing for installs that span multiple Honcho workspaces (e.g. work / personal / experiments). Rules are checked in order, first matching `cwdPrefix` wins, and `~` is expanded to `$HOME`. Takes precedence over the `globalOverride`, host-block, and default workspace resolution layers when any rule matches; falls through unchanged when none do, so single-workspace setups are unaffected.
+- `resolveWorkspaceFromCwd` normalises backslash path separators to forward slashes before prefix matching, so `workspaceRules` works correctly on Windows cwds (`C:\Users\alice\work\...`).
 
 ## [0.2.4] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- `workspaceRules` config field — cwd-prefix-based workspace routing for installs that span multiple Honcho workspaces (e.g. work / personal / experiments). Rules are checked in order, first matching `cwdPrefix` wins, and `~` is expanded to `$HOME`. Takes precedence over the `globalOverride`, host-block, and default workspace resolution layers when any rule matches; falls through unchanged when none do, so single-workspace setups are unaffected.
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -92,6 +92,48 @@ describe("resolveWorkspaceFromCwd", () => {
     ).toBe("work");
   });
 
+  test("matches Windows-style backslash cwd against forward-slash prefix", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "C:/Users/alice/work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work", rules),
+    ).toBe("work");
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work\\project-a", rules),
+    ).toBe("work");
+  });
+
+  test("matches Windows-style backslash cwd against backslash prefix", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "C:\\Users\\alice\\work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work", rules),
+    ).toBe("work");
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work\\project-a", rules),
+    ).toBe("work");
+  });
+
+  test("does not match Windows sibling directory", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "C:\\Users\\alice\\work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work-old", rules),
+    ).toBeNull();
+  });
+
+  test("normalises trailing backslash on Windows cwd", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "C:\\Users\\alice\\work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("C:\\Users\\alice\\work\\", rules),
+    ).toBe("work");
+  });
+
   test("respects rule order when multiple rules could match", () => {
     const ruleA: WorkspaceRule[] = [
       { cwdPrefix: "/a", workspace: "first" },

--- a/plugins/honcho/src/config.test.ts
+++ b/plugins/honcho/src/config.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test";
+import { homedir } from "os";
+import { join } from "path";
+import { resolveWorkspaceFromCwd, type WorkspaceRule } from "./config.js";
+
+describe("resolveWorkspaceFromCwd", () => {
+  test("returns null when no rules are provided", () => {
+    expect(resolveWorkspaceFromCwd("/any/path", undefined)).toBeNull();
+    expect(resolveWorkspaceFromCwd("/any/path", [])).toBeNull();
+  });
+
+  test("returns null when cwd matches no rule", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work", workspace: "work" },
+    ];
+    expect(resolveWorkspaceFromCwd("/home/alice/personal", rules)).toBeNull();
+  });
+
+  test("matches exact prefix", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work", workspace: "work" },
+    ];
+    expect(resolveWorkspaceFromCwd("/home/alice/work", rules)).toBe("work");
+  });
+
+  test("matches a subdirectory of the prefix", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work/project-a", rules),
+    ).toBe("work");
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work/project-a/src", rules),
+    ).toBe("work");
+  });
+
+  test("does not match when prefix is only a substring", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work", workspace: "work" },
+    ];
+    // /home/alice/work-old shares the prefix as a substring but is a sibling
+    // directory — must not match.
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work-old", rules),
+    ).toBeNull();
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/workshop", rules),
+    ).toBeNull();
+  });
+
+  test("first matching rule wins", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work/secret", workspace: "secret" },
+      { cwdPrefix: "/home/alice/work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work/secret/project", rules),
+    ).toBe("secret");
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work/other/project", rules),
+    ).toBe("work");
+  });
+
+  test("expands leading ~ to home directory", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "~/work", workspace: "work" },
+    ];
+    expect(
+      resolveWorkspaceFromCwd(join(homedir(), "work", "project"), rules),
+    ).toBe("work");
+  });
+
+  test("expands bare ~ as the home directory itself", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "~", workspace: "home-everything" },
+    ];
+    expect(resolveWorkspaceFromCwd(homedir(), rules)).toBe("home-everything");
+    expect(
+      resolveWorkspaceFromCwd(join(homedir(), "anything"), rules),
+    ).toBe("home-everything");
+  });
+
+  test("normalises trailing slashes on both rule prefix and cwd", () => {
+    const rules: WorkspaceRule[] = [
+      { cwdPrefix: "/home/alice/work/", workspace: "work" },
+    ];
+    expect(resolveWorkspaceFromCwd("/home/alice/work", rules)).toBe("work");
+    expect(resolveWorkspaceFromCwd("/home/alice/work/", rules)).toBe("work");
+    expect(
+      resolveWorkspaceFromCwd("/home/alice/work/project/", rules),
+    ).toBe("work");
+  });
+
+  test("respects rule order when multiple rules could match", () => {
+    const ruleA: WorkspaceRule[] = [
+      { cwdPrefix: "/a", workspace: "first" },
+      { cwdPrefix: "/a", workspace: "second" },
+    ];
+    expect(resolveWorkspaceFromCwd("/a", ruleA)).toBe("first");
+
+    const ruleB: WorkspaceRule[] = [
+      { cwdPrefix: "/a", workspace: "second" },
+      { cwdPrefix: "/a", workspace: "first" },
+    ];
+    expect(resolveWorkspaceFromCwd("/a", ruleB)).toBe("second");
+  });
+});

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -8,6 +8,43 @@ function sanitizeForSessionName(s: string): string {
   return s.toLowerCase().replace(/[^a-z0-9-_]/g, "-");
 }
 
+/** A cwd-based workspace routing rule.
+ *  Used when one Claude Code install spans multiple Honcho workspaces (e.g.
+ *  work projects vs personal projects vs experiments), and which workspace
+ *  to use depends on which directory you're working in. */
+export interface WorkspaceRule {
+  /** cwd prefix that triggers this rule. Supports leading `~` for $HOME.
+   *  Matched as a prefix (full path or path + `/`), not a glob. */
+  cwdPrefix: string;
+  /** Workspace name to use when this rule's cwdPrefix matches the active cwd. */
+  workspace: string;
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/** Resolve the active workspace from cwd-based rules.
+ *  Rules are checked in order; first matching `cwdPrefix` wins.
+ *  Returns `null` when no rule matches, so callers can fall through to
+ *  the existing host/env/default workspace resolution chain. */
+export function resolveWorkspaceFromCwd(
+  cwd: string,
+  rules?: WorkspaceRule[],
+): string | null {
+  if (!rules || rules.length === 0) return null;
+  const normalized = cwd.replace(/\/+$/, "");
+  for (const rule of rules) {
+    const prefix = expandHome(rule.cwdPrefix).replace(/\/+$/, "");
+    if (normalized === prefix || normalized.startsWith(prefix + "/")) {
+      return rule.workspace;
+    }
+  }
+  return null;
+}
+
 export interface MessageUploadConfig {
   /** Truncate user messages to this many tokens (undefined = no limit) */
   maxUserTokens?: number;
@@ -180,6 +217,10 @@ interface HonchoFileConfig {
    *  ignoring host-specific blocks. When false (default), each host
    *  uses its own block and flat fields are fallbacks only. */
   globalOverride?: boolean;
+  /** cwd-based workspace routing rules. Checked in order; first match wins.
+   *  Takes precedence over globalOverride, hostBlock, env, and defaults.
+   *  When no rule matches, falls through to the existing resolution chain. */
+  workspaceRules?: WorkspaceRule[];
   // Legacy flat fields (read-only fallbacks when no hosts block)
   cursorPeer?: string;
   claudePeer?: string;
@@ -292,7 +333,14 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     ?? raw.hosts?.[host.replace(/_/g, "-")]
     ?? raw.hosts?.[host.replace(/-/g, "_")];
 
-  if (raw.globalOverride === true) {
+  // cwd-based routing has highest priority. Falls through to the existing
+  // chain when no rule matches (so single-workspace setups are unaffected).
+  const cwdWorkspace = resolveWorkspaceFromCwd(process.cwd(), raw.workspaceRules);
+
+  if (cwdWorkspace !== null) {
+    workspace = cwdWorkspace;
+    aiPeer = hostBlock?.aiPeer ?? raw.aiPeer ?? DEFAULT_AI_PEER[host];
+  } else if (raw.globalOverride === true) {
     // Global override: flat fields apply to ALL hosts
     workspace = raw.workspace ?? DEFAULT_WORKSPACE[host];
     aiPeer = raw.aiPeer ?? hostBlock?.aiPeer ?? DEFAULT_AI_PEER[host];

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -35,9 +35,11 @@ export function resolveWorkspaceFromCwd(
   rules?: WorkspaceRule[],
 ): string | null {
   if (!rules || rules.length === 0) return null;
-  const normalized = cwd.replace(/\/+$/, "");
+  const normalized = cwd.replace(/\\/g, "/").replace(/\/+$/, "");
   for (const rule of rules) {
-    const prefix = expandHome(rule.cwdPrefix).replace(/\/+$/, "");
+    const prefix = expandHome(rule.cwdPrefix)
+      .replace(/\\/g, "/")
+      .replace(/\/+$/, "");
     if (normalized === prefix || normalized.startsWith(prefix + "/")) {
       return rule.workspace;
     }


### PR DESCRIPTION
## Summary

Adds a `workspaceRules` array to the config file. When set, each rule maps a `cwdPrefix` (with `~` expanded to `$HOME`) to a `workspace` name. Rules are checked in order; the first matching prefix wins. When no rule matches — or when `workspaceRules` is unset — resolution falls through unchanged to the existing `globalOverride` / host-block / default chain, so behaviour for current users is byte-identical.

```jsonc
{
  "hosts": { "claude_code": { "workspace": "default", "aiPeer": "claude" } },
  "workspaceRules": [
    { "cwdPrefix": "~/code/work",     "workspace": "work" },
    { "cwdPrefix": "~/code/personal", "workspace": "personal" },
    { "cwdPrefix": "~/code",          "workspace": "experiments" }
  ]
}
```

## Motivation

I run one Claude Code install across genuinely separate Honcho workspaces (work vs personal vs experiments) and want memory partitioned by domain so conclusions don't leak across contexts. Today the only workspace knobs are the flat `workspace` field, per-host blocks, and `globalOverride` — all of which resolve to a single workspace per process. Without cwd routing the only option is a wrapper script per project that exports a different config path, which is operationally clumsy.

## How it relates to other open routing PRs

The other in-flight routing PRs all partition memory **within** a single workspace:

| PR | What it routes |
|---|---|
| #24 (xlyk) | session name — glob keys into the existing `sessions{}` map |
| #32 (sasha-id) | session name — `per-repo` strategy from `git rev-parse --show-toplevel` |
| #33 (sasha-id) | host block / peer identity — `HONCHO_PROFILE` env var |
| #36 (sasha-id) | session name — `HONCHO_SESSION` env var |
| **this PR** | **workspace** — cwd-prefix → workspace map |

These are complementary. `HONCHO_PROFILE` (#33) is the closest neighbour — it routes the peer identity, this routes the workspace. They can coexist (e.g. cwd→workspace, then `HONCHO_PROFILE`→aiPeer within it).

## Implementation

- Two new exports in `plugins/honcho/src/config.ts`: `WorkspaceRule` interface and pure helper `resolveWorkspaceFromCwd(cwd, rules)`.
- One opt-in `workspaceRules?: WorkspaceRule[]` field on `HonchoFileConfig`.
- Hooked into `resolveConfig` at the top of the precedence chain — when `resolveWorkspaceFromCwd` returns a non-null value, it sets `workspace` and uses the host block's `aiPeer` (or default) for identity; otherwise the existing logic runs untouched.
- `~` expanded to `$HOME` for `cwdPrefix` and trailing slashes normalised on both sides.
- Prefix match is path-segment-aware: `~/code/work` does NOT match `~/code/work-old` (sibling directory).

## Tests

`plugins/honcho/src/config.test.ts` — 10 unit tests covering:

- no-rules / empty-rules short-circuit
- exact and subdirectory matching
- sibling-directory rejection (`/work` must not match `/work-old` or `/workshop`)
- first-match ordering with overlapping prefixes
- `~` expansion (with and without trailing path)
- trailing-slash normalisation on both rule prefix and cwd
- rule-order determinism among identical prefixes

```
$ bun test src/config.test.ts
 10 pass, 0 fail, 18 expect() calls, [44ms]
```

## Behaviour for existing users

- Config without `workspaceRules`: no-op, same code path as today.
- Config with `workspaceRules` but cwd matches no rule: also no-op.
- Only when both the field is set and a rule matches does new behaviour engage.

CHANGELOG updated with an `[Unreleased]` entry per `CONTRIBUTING.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workspace routing via a new workspaceRules config: assign workspaces based on cwd prefixes, evaluated in order with first-match precedence over other resolution methods. Home (`~`) expansion is supported; if no rule matches, existing resolution behavior applies.

* **Bug Fixes**
  * Normalized path separators and trailing slashes so rules work correctly on Windows and across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/claude-honcho/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->