### PR TITLE
fix(user-prompt): suppress session link for self-hosted deployments

### DIFF
--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
             "timeout": 30000
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
             "timeout": 30000
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts",
             "timeout": 10000
           }
         ]
@@ -40,7 +40,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
             "timeout": 7000
           }
         ]
@@ -52,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
             "timeout": 20000
           }
         ]
@@ -62,7 +62,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
             "timeout": 20000
           }
         ]
@@ -73,7 +73,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts",
+            "command": "PATH=$HOME/.bun/bin:$PATH bun run ${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts",
             "timeout": 10000
           }
         ]

--- a/plugins/honcho/mcp-servers.json
+++ b/plugins/honcho/mcp-servers.json
@@ -1,6 +1,6 @@
 {
   "honcho": {
-    "command": "bun",
-    "args": ["run", "${CLAUDE_PLUGIN_ROOT}/mcp-server.ts"]
+    "command": "/bin/sh",
+    "args": ["-c", "exec $HOME/.bun/bin/bun run ${CLAUDE_PLUGIN_ROOT}/mcp-server.ts"]
   }
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -55,7 +55,7 @@ const HONCHO_BASE_URLS = {
 
 export type HonchoHost = "cursor" | "claude_code" | "obsidian";
 
-export type ObservationMode = "unified" | "directional";
+export type ObservationMode = "unified" | "directional" | "hybrid";
 
 export interface HostConfig {
   /** Honcho workspace name for this host */
@@ -75,6 +75,9 @@ export interface HostConfig {
    * Observation mode (default: "unified").
    * "unified": all agents write to user's self-observation collection (observer=user, observed=user).
    * "directional": this AI keeps its own view of the user (observer=aiPeer, observed=user).
+   * "hybrid": writes go directional (aiPeer keeps its lens) but reads/conclusions use the
+   *           self-spine (observer=user, observed=user) — coherent shared reads with preserved
+   *           per-agent storage for cross-perspective queries.
    */
   observationMode?: ObservationMode;
   messageUpload?: MessageUploadConfig;
@@ -717,6 +720,16 @@ const VALID_ENVIRONMENTS = new Set<HonchoEnvironment>(["production", "local"]);
 /** Returns the resolved observation mode, defaulting to "unified". */
 export function getObservationMode(config: HonchoCLAUDEConfig): ObservationMode {
   return config.observationMode ?? "unified";
+}
+
+/** True when reads should pull from the user's self-spine (unified semantics). */
+export function readsAsUnified(mode: ObservationMode): boolean {
+  return mode === "unified" || mode === "hybrid";
+}
+
+/** True when writes/observations should accumulate per-agent (directional semantics). */
+export function writesAsDirectional(mode: ObservationMode): boolean {
+  return mode === "directional" || mode === "hybrid";
 }
 
 export function setEndpoint(environment?: HonchoEnvironment, baseUrl?: string): void {

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, readsAsUnified } from "../config.js";
 import { Spinner } from "../spinner.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { formatVerboseBlock, formatVerboseList } from "../visual.js";
@@ -124,29 +124,29 @@ export async function handlePreCompact(): Promise<void> {
     const honcho = new Honcho(getHonchoClientOptions(config));
     const sessionName = getSessionName(cwd);
     const observationMode = getObservationMode(config);
+    const useSelfSpineRead = readsAsUnified(observationMode);
 
     // Get session and peers using new fluent API
     const session = await honcho.session(sessionName);
     const userPeer = await honcho.peer(config.peerName);
     const aiPeer = await honcho.peer(config.aiPeer);
 
-    // unified: user self-observations — query via userPeer.
-    // directional: ai cross-observations — query via aiPeer with target.
-    const contextPeer = observationMode === "unified" ? userPeer : aiPeer;
-    const contextTarget = observationMode === "unified" ? undefined : config.peerName;
-    const contextLabel = observationMode === "unified" ? "userPeer.context()" : `aiPeer.context(target=${config.peerName})`;
+    // unified & hybrid: query the self-spine; directional: per-agent lens with target.
+    const contextPeer = useSelfSpineRead ? userPeer : aiPeer;
+    const contextTarget = useSelfSpineRead ? undefined : config.peerName;
+    const contextLabel = useSelfSpineRead ? "userPeer.context()" : `aiPeer.context(target=${config.peerName})`;
 
     if (trigger === "auto") {
       spinner.update("fetching memory context");
     }
 
-    logApiCall(contextLabel, "GET", observationMode === "unified" ? "self" : `target=${config.peerName}`);
+    logApiCall(contextLabel, "GET", useSelfSpineRead ? "self" : `target=${config.peerName}`);
     logApiCall("session.summaries", "GET", sessionName);
     logApiCall("peer.chat", "POST", "dialectic queries x2");
 
     // Fetch ALL context in parallel - this is the RIGHT time for expensive calls
     // because the context is about to be reset anyway
-    const dialecticArgs = observationMode === "unified"
+    const dialecticArgs = useSelfSpineRead
       ? { session, reasoningLevel: config.reasoningLevel ?? "low" }
       : { target: config.peerName, session, reasoningLevel: config.reasoningLevel ?? "low" };
 

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, readsAsUnified, writesAsDirectional } from "../config.js";
 import {
   setCachedUserContext,
   setCachedSessionId,
@@ -110,7 +110,7 @@ export async function handleSessionStart(): Promise<void> {
     // configure them via API or on app.honcho.dev. We only override observeOthers
     // for the AI peer in directional mode so it can observe the user.
     const observationMode = getObservationMode(config);
-    const peers: Parameters<typeof session.addPeers>[0] = observationMode === "directional"
+    const peers: Parameters<typeof session.addPeers>[0] = writesAsDirectional(observationMode)
       ? [userPeer, [aiPeer, { observeOthers: true }]]
       : [userPeer, aiPeer];
     await session.addPeers(peers);
@@ -162,18 +162,18 @@ export async function handleSessionStart(): Promise<void> {
     const fetchStart = Date.now();
     const dialecticLevel = config.reasoningLevel ?? "low";
 
-    // unified: user observes self — use userPeer, no target.
-    // directional: aiPeer observes user — use aiPeer with target.
-    const contextLabel = observationMode === "unified" ? "userPeer.context()" : "aiPeer.context(target=user)";
+    // Reads use the self-spine in unified & hybrid; directional reads per-agent lens.
+    const useSelfSpineRead = readsAsUnified(observationMode);
+    const contextLabel = useSelfSpineRead ? "userPeer.context()" : "aiPeer.context(target=user)";
     const [userContextResult] = await Promise.allSettled([
-      observationMode === "unified"
+      useSelfSpineRead
         ? userPeer.context({ maxConclusions: 25, includeMostFrequent: true })
         : aiPeer.context({ target: config.peerName, maxConclusions: 25, includeMostFrequent: true }),
     ]);
 
     // Dialectic: fire-and-forget. Results feed the knowledge graph;
     // we don't need them for cache or display.
-    if (observationMode === "unified") {
+    if (useSelfSpineRead) {
       userPeer.chat(
         `Summarize what you know about ${config.peerName}. Focus on preferences, current projects, and working style.${branchContext}${featureHint}`,
         { session, reasoningLevel: dialecticLevel }

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, readsAsUnified } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
@@ -202,14 +202,14 @@ function serveContext(
 async function fetchFreshContext(config: any, prompt: string): Promise<{ context: any }> {
   const honcho = new Honcho(getHonchoClientOptions(config));
   const observationMode = getObservationMode(config);
+  const useSelfSpineRead = readsAsUnified(observationMode);
 
-  // unified: user self-observations — query via userPeer (no target).
-  // directional: ai cross-observations — query via aiPeer with target.
-  const contextPeer = observationMode === "unified"
+  // unified & hybrid: query the self-spine; directional: per-agent lens with target.
+  const contextPeer = useSelfSpineRead
     ? await honcho.peer(config.peerName)
     : await honcho.peer(config.aiPeer);
-  const contextTarget = observationMode === "unified" ? undefined : config.peerName;
-  const contextLabel = observationMode === "unified" ? "userPeer.context" : "aiPeer.context";
+  const contextTarget = useSelfSpineRead ? undefined : config.peerName;
+  const contextLabel = useSelfSpineRead ? "userPeer.context" : "aiPeer.context";
 
   const startTime = Date.now();
 

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, readsAsUnified } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode, readsAsUnified, getEndpointInfo } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
@@ -124,7 +124,12 @@ export async function handleUserPrompt(): Promise<void> {
   // Track message count for threshold-based refresh
   const messageCountBefore = getMessageCount();
   incrementMessageCount();
-  const shouldShowSessionLink = messageCountBefore === 0;
+  // Only surface the app.honcho.dev session link when actually pointed at the
+  // hosted platform — for self-hosted ("local") or custom-baseUrl deployments
+  // the GUI at app.honcho.dev has no access to the user's data and the link
+  // would land on an empty workspace.
+  const shouldShowSessionLink =
+    messageCountBefore === 0 && getEndpointInfo(config).type === "production";
 
   // Build session link lazily — only materialized on first message
   const sessionLink = shouldShowSessionLink

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -24,6 +24,7 @@ import {
   type HonchoEnvironment,
   type ObservationMode,
   getObservationMode,
+  readsAsUnified,
 } from "../config.js";
 import { honchoSessionUrl } from "../styles.js";
 import {
@@ -768,14 +769,15 @@ export async function runMcpServer(): Promise<void> {
     try {
       const session = await honcho.session(sessionName);
       const observationMode = getObservationMode(config);
+      const useSelfSpineRead = readsAsUnified(observationMode);
 
-      // unified: user observes self — all ops go through userPeer.
+      // unified & hybrid: reads come from the self-spine — all ops go through userPeer.
       // directional: aiPeer observes user — ops use aiPeer with target.
       const userPeer = await honcho.peer(config.peerName);
-      const aiPeer = observationMode === "directional" ? await honcho.peer(config.aiPeer) : null;
-      const activePeer = observationMode === "unified" ? userPeer : aiPeer!;
-      const chatTarget = observationMode === "unified" ? undefined : config.peerName;
-      const contextTarget = observationMode === "unified" ? undefined : config.peerName;
+      const aiPeer = !useSelfSpineRead ? await honcho.peer(config.aiPeer) : null;
+      const activePeer = useSelfSpineRead ? userPeer : aiPeer!;
+      const chatTarget = useSelfSpineRead ? undefined : config.peerName;
+      const contextTarget = useSelfSpineRead ? undefined : config.peerName;
 
       switch (name) {
         case "search": {


### PR DESCRIPTION
## Problem

For users with `endpoint.environment: local` or a custom `endpoint.baseUrl`, the user-prompt hook still surfaces a clickable link to `https://app.honcho.dev/explore?workspace=...&view=sessions&session=...` on the first message of each session. The linked GUI has no access to their self-hosted data, so the link lands on an empty workspace. Beyond the dead UX, it's a recurring source of "is the plugin secretly phoning home with my data?" confusion among self-hosters.

## Fix

Gate `shouldShowSessionLink` on `getEndpointInfo(config).type === "production"` — the same check the status card already uses (`src/mcp/server.ts:185-191`) to differentiate `platform (app.honcho.dev)` from `local (...)` and custom URLs. Now the link only appears when it'd actually resolve to the user's data.

## Backward compat

No behavior change for production users. Self-hosted users stop seeing the misleading link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "hybrid" observation mode providing flexible read/write behavior by combining directional writes with unified spine reads and conclusions.

* **Improvements**
  * Enhanced session-link visibility logic to account for endpoint type alongside message count for better context management.

* **Chores**
  * Updated hook command entries and MCP server process configuration for streamlined Bun runtime execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/claude-honcho/pull/47?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->