### PR TITLE
feat: nag users when the honcho plugin is behind the published version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-honcho will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Version-update nag: warns on first prompt when the installed plugin is behind the published version (checks for updates at most once a day; silent on failure).
+
 ## [0.2.4] - 2026-04-01
 
 ### Added

--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -6,6 +6,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/check-version.sh\"",
+            "timeout": 2000
+          },
+          {
+            "type": "command",
             "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
             "timeout": 30000,
             "async": true

--- a/plugins/honcho/scripts/check-version.sh
+++ b/plugins/honcho/scripts/check-version.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Nag users when their installed honcho plugin lags behind the published
+# version. Throttled to one network check per 24h. Dep-free; uses curl + sort -V.
+set -eu
+
+ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+DATA="${CLAUDE_PLUGIN_DATA:-}"
+
+[ -z "$ROOT" ] && exit 0
+[ -z "$DATA" ] && exit 0
+
+mkdir -p "$DATA"
+STAMP="${DATA}/.version-check"
+FLAG="${DATA}/.version-stale"
+
+# Throttle: skip if checked within last 24h.
+if [ -f "$STAMP" ]; then
+  if find "$STAMP" -mtime -1 -print 2>/dev/null | grep -q .; then
+    exit 0
+  fi
+fi
+
+LOCAL_VERSION=$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+  "${ROOT}/.claude-plugin/plugin.json" | head -n1)
+[ -z "$LOCAL_VERSION" ] && exit 0
+
+REMOTE_JSON=$(curl --max-time 2 -fsSL \
+  "https://raw.githubusercontent.com/plastic-labs/claude-honcho/main/.claude-plugin/marketplace.json" \
+  2>/dev/null) || exit 0
+
+# Pull the version of the "honcho" plugin entry. Naive but adequate for our schema.
+REMOTE_VERSION=$(printf '%s' "$REMOTE_JSON" \
+  | tr -d '\n' \
+  | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"honcho"[^}]*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+  | head -n1)
+[ -z "$REMOTE_VERSION" ] && exit 0
+
+# Touch stamp regardless of outcome so we don't keep hammering the network.
+touch "$STAMP"
+
+# If local >= remote, clear any stale flag and exit.
+LATEST=$(printf '%s\n%s\n' "$LOCAL_VERSION" "$REMOTE_VERSION" | sort -V | tail -n1)
+if [ "$LOCAL_VERSION" = "$LATEST" ]; then
+  rm -f "$FLAG"
+  exit 0
+fi
+
+printf 'honcho plugin: v%s installed, v%s available. To update: run /plugins, search honcho, press Enter, choose "Update now".\n' \
+  "$LOCAL_VERSION" "$REMOTE_VERSION" > "$FLAG"
+exit 0

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,4 +1,6 @@
 import { Honcho } from "@honcho-ai/sdk";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
 import {
   getCachedUserContext,
@@ -72,6 +74,18 @@ function formatSessionLink(sessionUrl: string): string {
   return `view your session in honcho GUI: ${sessionUrl}`;
 }
 
+function readVersionNag(): string | undefined {
+  const dataDir = process.env.CLAUDE_PLUGIN_DATA;
+  if (!dataDir) return undefined;
+  const flag = join(dataDir, ".version-stale");
+  if (!existsSync(flag)) return undefined;
+  try {
+    return readFileSync(flag, "utf8").trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * UserPromptSubmit hook — serves cached context instantly, refreshes when stale.
  *
@@ -124,12 +138,18 @@ export async function handleUserPrompt(): Promise<void> {
   // Track message count for threshold-based refresh
   const messageCountBefore = getMessageCount();
   incrementMessageCount();
-  const shouldShowSessionLink = messageCountBefore === 0;
-
-  // Build session link lazily — only materialized on first message
-  const sessionLink = shouldShowSessionLink
-    ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
-    : undefined;
+  // Stagger the one-off banners so the first prompt isn't crowded. The
+  // version-update nag (if stale) takes the first message and bumps the GUI
+  // session link to the second; with no nag, the link shows on the first.
+  // The nag flag is written at SessionStart and stable for the session, so
+  // its presence on message 2 tells us the link hasn't been shown yet.
+  const nag = readVersionNag();
+  const sessionLink =
+    messageCountBefore === 0
+      ? nag ?? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+      : messageCountBefore === 1 && nag
+        ? formatSessionLink(honchoSessionUrl(config.workspace, sessionName))
+        : undefined;
 
   // Skip trivial prompts — no context needed for "y", "ok", etc.
   if (shouldSkipContextRetrieval(prompt)) {


### PR DESCRIPTION
A dep-free check-version.sh runs at SessionStart, comparing the local plugin.json version against the published marketplace.json version. When behind, it writes a .version-stale flag. user-prompt.ts surfaces the nag as a systemMessage on the first prompt and staggers the existing honcho GUI session link to the second so the first prompt isn't crowded. Replaces the old deps-check nag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a version-update nag that warns when the installed honcho plugin is behind the published version; checks at most once per day and fails silently on error.
  * Triggered at session start so the check runs before the first prompt.

* **Bug Fixes / UX**
  * Adjusted session link display timing to avoid showing it on the first prompt when a version nag is present.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/plastic-labs/claude-honcho/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->