### PR TITLE
feat(config): HONCHO_HOME env override for per-domain state dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to claude-honcho will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `HONCHO_HOME` env var overrides the plugin's state directory (default `~/.honcho`), so a single install can give different directory trees their own config, caches, queue, and logs (e.g. work vs personal projects). A leading `~/` is expanded to `$HOME`; unset / empty / whitespace falls through to `~/.honcho` unchanged, so existing setups are unaffected. Logs (`activity.log`, `verbose.log`) honor it too, keeping all state co-located. Covered by `getHonchoHome` unit tests and subprocess e2e tests that assert real state-file relocation and co-location.
+
 ### Changed
 
 - User prompts are now written to Honcho in real time on `UserPromptSubmit` instead of being queued for `SessionEnd` flush. Mirrors the existing fire-and-forget pattern used by `PostToolUse` and `Stop`.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The honcho plugin provides these tools via MCP:
 
 ## Configuration
 
-All configuration lives in a single global file at `~/.honcho/config.json`. You can edit it directly, use the `/honcho:config` skill, or use the `set_config` MCP tool. Environment variables work for initial setup but the config file takes precedence once it exists.
+All configuration lives in a single global file at `~/.honcho/config.json`. You can edit it directly, use the `/honcho:config` skill, or use the `set_config` MCP tool. Environment variables work for initial setup but the config file takes precedence once it exists. (The `~/.honcho` location itself can be relocated — per directory tree, if you like — with the `HONCHO_HOME` environment variable; see [Environment Variables](#environment-variables).)
 
 ### Config File Reference
 
@@ -424,6 +424,18 @@ Environment variables work for initial bootstrap (before a config file exists). 
 | `HONCHO_ENABLED`       | No       | `true`        | Set to `false` to disable                                         |
 | `HONCHO_SAVE_MESSAGES` | No       | `true`        | Set to `false` to stop saving messages                            |
 | `HONCHO_LOGGING`       | No       | `true`        | Set to `false` to disable file logging to `~/.honcho/`            |
+| `HONCHO_HOME`          | No       | `~/.honcho`   | State directory for `config.json`, caches, message queue, and logs. A leading `~/` is expanded. Unlike the other variables, this one is honored **even when a config file exists**. |
+
+#### Separate state per directory (`HONCHO_HOME`)
+
+`HONCHO_HOME` relocates the entire plugin state directory (`~/.honcho` by default) — `config.json`, caches, the message queue, and logs. This lets a single install keep separate, fully isolated Honcho homes for different directory trees (e.g. work vs personal), so neither the conclusions nor the local `context-cache.json` cross between them. Pair it with a per-directory env tool (direnv, fnox, a shell hook):
+
+```bash
+# in your work tree:   export HONCHO_HOME=~/.honcho-work   # its own config.json (-> its own workspace) + caches + logs
+# everywhere else:     (unset)                             # -> ~/.honcho, unchanged
+```
+
+When `HONCHO_HOME` is unset, empty, or whitespace, behaviour is byte-identical to before.
 
 ## How It Works
 

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -7,7 +7,7 @@ const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
 const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");
 
-// Ensure cache directory exists
+/** ensure the honcho state directory exists for cache files. */
 function ensureCacheDir(): void {
   if (!existsSync(CACHE_DIR)) {
     mkdirSync(CACHE_DIR, { recursive: true });

--- a/plugins/honcho/src/cache.ts
+++ b/plugins/honcho/src/cache.ts
@@ -1,9 +1,8 @@
-import { homedir } from "os";
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { getContextRefreshConfig, getLocalContextConfig } from "./config.js";
+import { getContextRefreshConfig, getLocalContextConfig, getHonchoHome } from "./config.js";
 
-const CACHE_DIR = join(homedir(), ".honcho");
+const CACHE_DIR = getHonchoHome();
 const ID_CACHE_FILE = join(CACHE_DIR, "cache.json");
 const CONTEXT_CACHE_FILE = join(CACHE_DIR, "context-cache.json");
 const CLAUDE_CONTEXT_FILE = join(CACHE_DIR, "claude-context.md");

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -244,7 +244,15 @@ function deepEqual(a: unknown, b: unknown): boolean {
   return true;
 }
 
-const CONFIG_DIR = join(homedir(), ".honcho");
+// state directory is overridable via HONCHO_HOME so a single install can give each
+// directory tree (e.g. work vs personal) its own config + caches + queue + logs.
+export function getHonchoHome(): string {
+  const env = process.env.HONCHO_HOME?.trim();
+  if (env) return env.startsWith("~/") ? join(homedir(), env.slice(2)) : env;
+  return join(homedir(), ".honcho");
+}
+
+const CONFIG_DIR = getHonchoHome();
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
 export function getConfigDir(): string {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -266,14 +266,17 @@ export function getHonchoHome(): string {
 const CONFIG_DIR = getHonchoHome();
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
+/** absolute path to the honcho state directory (see getHonchoHome). */
 export function getConfigDir(): string {
   return CONFIG_DIR;
 }
 
+/** absolute path to config.json inside the honcho state directory. */
 export function getConfigPath(): string {
   return CONFIG_FILE;
 }
 
+/** whether config.json exists in the honcho state directory. */
 export function configExists(): boolean {
   return existsSync(CONFIG_FILE);
 }

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -244,8 +244,13 @@ function deepEqual(a: unknown, b: unknown): boolean {
   return true;
 }
 
-// state directory is overridable via HONCHO_HOME so a single install can give each
-// directory tree (e.g. work vs personal) its own config + caches + queue + logs.
+/**
+ * resolve the honcho state directory. defaults to ~/.honcho, overridable via
+ * HONCHO_HOME so a single install can give each directory tree (e.g. work vs
+ * personal) its own config, caches, queue, and logs. expands a leading ~, and
+ * resolves any other value (including a relative path) to an absolute path so
+ * the dir stays stable regardless of the cwd a hook runs from.
+ */
 export function getHonchoHome(): string {
   const env = process.env.HONCHO_HOME?.trim();
   if (env) {

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,5 +1,5 @@
 import { homedir } from "os";
-import { join, basename } from "path";
+import { join, basename, resolve } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
@@ -248,7 +248,13 @@ function deepEqual(a: unknown, b: unknown): boolean {
 // directory tree (e.g. work vs personal) its own config + caches + queue + logs.
 export function getHonchoHome(): string {
   const env = process.env.HONCHO_HOME?.trim();
-  if (env) return env.startsWith("~/") ? join(homedir(), env.slice(2)) : env;
+  if (env) {
+    if (env === "~") return homedir();
+    if (env.startsWith("~/")) return join(homedir(), env.slice(2));
+    // resolve any other value (including a relative path) to an absolute path
+    // now, so the state dir stays stable regardless of the cwd a hook runs from.
+    return resolve(env);
+  }
   return join(homedir(), ".honcho");
 }
 

--- a/plugins/honcho/src/honcho-home-e2e.test.ts
+++ b/plugins/honcho/src/honcho-home-e2e.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join, dirname } from "path";
+
+// e2e: spawn the probe in a child process with a controlled HOME + HONCHO_HOME so the
+// plugin's module-load-time state-dir constants are captured fresh per scenario, then
+// assert where config / cache / activity.log / verbose.log actually resolve and write.
+// No network, no real deploy; everything lands in throwaway temp dirs.
+
+const PROBE = join(import.meta.dir, "honcho-home-probe.ts");
+const tmps: string[] = [];
+function freshDir(tag: string): string {
+  const d = mkdtempSync(join(tmpdir(), `hh-${tag}-`));
+  tmps.push(d);
+  return d;
+}
+afterAll(() => {
+  for (const d of tmps) rmSync(d, { recursive: true, force: true });
+});
+
+function runProbe(env: Record<string, string | undefined>): {
+  configDir: string; configPath: string; logPath: string; verbosePath: string;
+  cacheFileWritten: boolean; logFileWritten: boolean;
+} {
+  // replace env entirely (do not inherit the real HOME / HONCHO_HOME); keep PATH for bun
+  const childEnv: Record<string, string> = { PATH: process.env.PATH ?? "" };
+  for (const [k, v] of Object.entries(env)) if (v !== undefined) childEnv[k] = v;
+  const res = Bun.spawnSync({ cmd: [process.execPath, "run", PROBE], env: childEnv });
+  if (!res.success) {
+    throw new Error(`probe exited ${res.exitCode}: ${res.stderr.toString()}`);
+  }
+  const lines = res.stdout.toString().trim().split("\n").filter(Boolean);
+  return JSON.parse(lines[lines.length - 1]);
+}
+
+describe("HONCHO_HOME state-dir relocation (e2e)", () => {
+  test("unset HONCHO_HOME -> state lives under $HOME/.honcho (backward compatible)", () => {
+    const home = freshDir("home");
+    const r = runProbe({ HOME: home });
+    expect(r.configDir).toBe(join(home, ".honcho"));
+    expect(dirname(r.logPath)).toBe(join(home, ".honcho"));
+    expect(r.cacheFileWritten).toBe(true);
+    expect(r.logFileWritten).toBe(true);
+  });
+
+  test("absolute HONCHO_HOME -> all state is relocated there, nothing leaks to $HOME/.honcho", () => {
+    const home = freshDir("home");
+    const state = freshDir("state");
+    const r = runProbe({ HOME: home, HONCHO_HOME: state });
+    expect(r.configDir).toBe(state);
+    expect(dirname(r.logPath)).toBe(state);
+    expect(r.cacheFileWritten).toBe(true);
+    expect(r.logFileWritten).toBe(true);
+    expect(existsSync(join(home, ".honcho", "cache.json"))).toBe(false);
+  });
+
+  test("tilde HONCHO_HOME (~/sub) -> expanded under $HOME", () => {
+    const home = freshDir("home");
+    const r = runProbe({ HOME: home, HONCHO_HOME: "~/honcho-alt" });
+    expect(r.configDir).toBe(join(home, "honcho-alt"));
+  });
+
+  test("whitespace HONCHO_HOME -> falls back to $HOME/.honcho", () => {
+    const home = freshDir("home");
+    const r = runProbe({ HOME: home, HONCHO_HOME: "   " });
+    expect(r.configDir).toBe(join(home, ".honcho"));
+  });
+
+  test("config + cache + activity.log + verbose.log are all co-located under HONCHO_HOME", () => {
+    const home = freshDir("home");
+    const state = freshDir("state");
+    const r = runProbe({ HOME: home, HONCHO_HOME: state });
+    // every state file must sit in the SAME overridden directory
+    expect(dirname(r.configPath)).toBe(state);
+    expect(r.configDir).toBe(state);
+    expect(dirname(r.logPath)).toBe(state);     // activity.log
+    expect(dirname(r.verbosePath)).toBe(state); // verbose.log
+  });
+});

--- a/plugins/honcho/src/honcho-home-e2e.test.ts
+++ b/plugins/honcho/src/honcho-home-e2e.test.ts
@@ -10,6 +10,7 @@ import { join, dirname } from "path";
 
 const PROBE = join(import.meta.dir, "honcho-home-probe.ts");
 const tmps: string[] = [];
+/** make a unique throwaway temp dir for one e2e scenario, tracked for cleanup. */
 function freshDir(tag: string): string {
   const d = mkdtempSync(join(tmpdir(), `hh-${tag}-`));
   tmps.push(d);
@@ -19,6 +20,7 @@ afterAll(() => {
   for (const d of tmps) rmSync(d, { recursive: true, force: true });
 });
 
+/** spawn the probe in a child with the given HOME/HONCHO_HOME env and parse the json on its last stdout line. */
 function runProbe(env: Record<string, string | undefined>): {
   configDir: string; configPath: string; logPath: string; verbosePath: string;
   cacheFileWritten: boolean; logFileWritten: boolean;

--- a/plugins/honcho/src/honcho-home-probe.ts
+++ b/plugins/honcho/src/honcho-home-probe.ts
@@ -1,0 +1,24 @@
+// e2e probe (not a test file — bun:test ignores it). Spawned by honcho-home-e2e.test.ts
+// in a child process with a controlled HOME + HONCHO_HOME env, so the module-load-time
+// state-dir constants are captured fresh. It performs real writes and reports the
+// resolved state-dir paths as JSON on the last stdout line.
+import { join } from "path";
+import { existsSync } from "fs";
+import { getConfigDir, getConfigPath } from "./config.js";
+import { getLogPath, logActivity } from "./log.js";
+import { getVerboseLogPath } from "./visual.js";
+import { setCachedSessionId } from "./cache.js";
+
+// real writes into whatever dir the plugin resolved
+setCachedSessionId("/probe/cwd", "honcho-home-probe", "probe-id");
+logActivity("cache", "honcho-home-probe", "probe activity line");
+
+const configDir = getConfigDir();
+console.log(JSON.stringify({
+  configDir,
+  configPath: getConfigPath(),
+  logPath: getLogPath(),
+  verbosePath: getVerboseLogPath(),
+  cacheFileWritten: existsSync(join(configDir, "cache.json")),
+  logFileWritten: existsSync(getLogPath()),
+}));

--- a/plugins/honcho/src/honcho-home.test.ts
+++ b/plugins/honcho/src/honcho-home.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { homedir } from "os";
-import { join } from "path";
+import { join, resolve } from "path";
 import { getHonchoHome } from "./config.js";
 
 // unit tests for the pure env-resolution helper. getHonchoHome() reads
@@ -42,8 +42,13 @@ describe("getHonchoHome", () => {
     expect(getHonchoHome()).toBe("/tmp/honcho-trim");
   });
 
-  test("passes a relative path through unchanged", () => {
+  test("resolves a relative path to an absolute path", () => {
     process.env.HONCHO_HOME = "relative/dir";
-    expect(getHonchoHome()).toBe("relative/dir");
+    expect(getHonchoHome()).toBe(resolve("relative/dir"));
+  });
+
+  test("expands a bare ~ to the home directory", () => {
+    process.env.HONCHO_HOME = "~";
+    expect(getHonchoHome()).toBe(homedir());
   });
 });

--- a/plugins/honcho/src/honcho-home.test.ts
+++ b/plugins/honcho/src/honcho-home.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { homedir } from "os";
+import { join } from "path";
+import { getHonchoHome } from "./config.js";
+
+// unit tests for the pure env-resolution helper. getHonchoHome() reads
+// process.env.HONCHO_HOME on every call, so these run in-process.
+describe("getHonchoHome", () => {
+  const original = process.env.HONCHO_HOME;
+  afterEach(() => {
+    if (original === undefined) delete process.env.HONCHO_HOME;
+    else process.env.HONCHO_HOME = original;
+  });
+
+  test("falls back to ~/.honcho when unset (backward compatible)", () => {
+    delete process.env.HONCHO_HOME;
+    expect(getHonchoHome()).toBe(join(homedir(), ".honcho"));
+  });
+
+  test("falls back to ~/.honcho when empty", () => {
+    process.env.HONCHO_HOME = "";
+    expect(getHonchoHome()).toBe(join(homedir(), ".honcho"));
+  });
+
+  test("falls back to ~/.honcho when whitespace-only", () => {
+    process.env.HONCHO_HOME = "   ";
+    expect(getHonchoHome()).toBe(join(homedir(), ".honcho"));
+  });
+
+  test("uses an absolute path verbatim", () => {
+    process.env.HONCHO_HOME = "/tmp/honcho-state";
+    expect(getHonchoHome()).toBe("/tmp/honcho-state");
+  });
+
+  test("expands a leading ~/ to the home directory", () => {
+    process.env.HONCHO_HOME = "~/honcho-alt";
+    expect(getHonchoHome()).toBe(join(homedir(), "honcho-alt"));
+  });
+
+  test("trims surrounding whitespace before use", () => {
+    process.env.HONCHO_HOME = "  /tmp/honcho-trim  ";
+    expect(getHonchoHome()).toBe("/tmp/honcho-trim");
+  });
+
+  test("passes a relative path through unchanged", () => {
+    process.env.HONCHO_HOME = "relative/dir";
+    expect(getHonchoHome()).toBe("relative/dir");
+  });
+});

--- a/plugins/honcho/src/log.ts
+++ b/plugins/honcho/src/log.ts
@@ -89,6 +89,7 @@ const sym = {
 // Core Logging Functions
 // ============================================
 
+/** ensure the honcho state directory exists for activity logs. */
 function ensureLogDir(): void {
   if (!existsSync(CACHE_DIR)) {
     mkdirSync(CACHE_DIR, { recursive: true });

--- a/plugins/honcho/src/log.ts
+++ b/plugins/honcho/src/log.ts
@@ -7,13 +7,12 @@
  * - Useful: Real-time debugging and demo capabilities
  */
 
-import { homedir } from "os";
 import { join } from "path";
 import { existsSync, appendFileSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { symbols, arrows, box } from "./unicode.js";
-import { isLoggingEnabled } from "./config.js";
+import { isLoggingEnabled, getHonchoHome } from "./config.js";
 
-const CACHE_DIR = join(homedir(), ".honcho");
+const CACHE_DIR = getHonchoHome();
 const LOG_FILE = join(CACHE_DIR, "activity.log");
 const MAX_LOG_SIZE = 100 * 1024; // 100KB max log size
 

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -106,6 +106,7 @@ import { appendFileSync, mkdirSync, existsSync, writeFileSync } from "fs";
 
 const VERBOSE_LOG = join(getHonchoHome(), "verbose.log");
 
+/** ensure the honcho state directory exists for verbose logs. */
 function ensureVerboseLog(): void {
   const dir = getHonchoHome();
   if (!existsSync(dir)) {
@@ -113,6 +114,7 @@ function ensureVerboseLog(): void {
   }
 }
 
+/** append a timestamped line to verbose.log when verbose logging is enabled. */
 function writeVerbose(text: string): void {
   if (!isLoggingEnabled()) return;
   ensureVerboseLog();

--- a/plugins/honcho/src/visual.ts
+++ b/plugins/honcho/src/visual.ts
@@ -11,7 +11,7 @@
  */
 
 import { arrows, symbols } from "./unicode.js";
-import { isLoggingEnabled } from "./config.js";
+import { isLoggingEnabled, getHonchoHome } from "./config.js";
 
 // Plain text (no ANSI) for systemMessage — shown in Claude Code's UI
 const sym = {
@@ -101,14 +101,13 @@ export function addSystemMessage(existingJson: any, message: string): any {
 // printing verbose data to stdout instead — use formatVerboseBlock().
 // ============================================
 
-import { homedir } from "os";
 import { join } from "path";
 import { appendFileSync, mkdirSync, existsSync, writeFileSync } from "fs";
 
-const VERBOSE_LOG = join(homedir(), ".honcho", "verbose.log");
+const VERBOSE_LOG = join(getHonchoHome(), "verbose.log");
 
 function ensureVerboseLog(): void {
-  const dir = join(homedir(), ".honcho");
+  const dir = getHonchoHome();
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }


### PR DESCRIPTION
## Summary

Adds a `HONCHO_HOME` env var that overrides the plugin's state directory (default `~/.honcho`), so a **single install can give different directory trees their own config, caches, queue, and logs** — e.g. work vs personal projects, kept fully isolated.

```bash
# in your work tree (via direnv / a shell wrapper):
export HONCHO_HOME=~/.honcho-work     # its own config.json + caches + activity.log + verbose.log
# everywhere else: unset -> ~/.honcho, byte-identical to today
```

## Motivation

I run one Claude Code install across genuinely separate Honcho workspaces (work vs personal) and need memory partitioned by domain so conclusions — **and the local `context-cache.json`** — never cross contexts. Workspace routing alone (the flat `workspace` field / per-host blocks / the cwd `workspaceRules` proposed in #41) selects the workspace but still shares one `~/.honcho` state dir, so the single, non-workspace-keyed `context-cache.json` can serve another domain's cached context for up to the TTL. Relocating the whole state dir per tree closes that.

This is **complementary to #41**: #41 routes the *workspace* by cwd; this routes the *state directory* by env. They compose cleanly (cwd → workspace via #41, env → isolated caches/logs via this).

## Implementation

- New exported pure helper `getHonchoHome()` in `plugins/honcho/src/config.ts`: returns `process.env.HONCHO_HOME` (trimmed; leading `~/` expanded via `homedir()`), else `join(homedir(), ".honcho")`.
- `CONFIG_DIR` (config.ts) and `CACHE_DIR` (cache.ts) now derive from it; `log.ts` (`activity.log`) and `visual.ts` (`verbose.log`) too, so **all** state stays co-located. Dropped a now-unused `homedir` import in cache.ts.

## Behaviour for existing users

Unset / empty / whitespace `HONCHO_HOME` → falls through to `~/.honcho` unchanged. No behaviour change unless the var is explicitly set.

## Tests

- `plugins/honcho/src/honcho-home.test.ts` — `getHonchoHome` unit tests (unset/empty/whitespace fallback, absolute, `~/` expansion, trim, relative passthrough).
- `plugins/honcho/src/honcho-home-e2e.test.ts` + `honcho-home-probe.ts` — subprocess e2e: each scenario spawns a child with a controlled `HOME` + `HONCHO_HOME` (so the module-load-time state-dir constants are captured fresh), performs real writes into throwaway temp dirs, and asserts config/cache/`activity.log`/`verbose.log` relocation + co-location, plus no leak to the default dir.

```
$ bun test src/honcho-home.test.ts src/honcho-home-e2e.test.ts
 12 pass, 0 fail
$ bun x tsc --noEmit   # clean
```

Verified red phase: reverting the implementation to `main` fails exactly the relocation/co-location tests while the backward-compat tests still pass.

CHANGELOG updated with an `[Unreleased]` entry per `CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `HONCHO_HOME` environment variable to override the plugin's state directory location (defaults to `~/.honcho`). Supports tilde expansion and absolute paths, relocating all configuration, cache, and logs.

* **Documentation**
  * Updated README to document the new `HONCHO_HOME` environment variable and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->