### PR TITLE
fix(mcp): raise dialectic chat client timeout 30s → 60s

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -692,12 +692,12 @@ export function getHonchoBaseUrl(config: HonchoCLAUDEConfig): string {
   return getHonchoBaseUrlForEndpoint(config.endpoint);
 }
 
-export function getHonchoClientOptions(config: HonchoCLAUDEConfig): HonchoClientOptions {
+export function getHonchoClientOptions(config: HonchoCLAUDEConfig, timeoutMs: number = 8000): HonchoClientOptions {
   return {
     apiKey: config.apiKey,
     baseURL: getHonchoBaseUrl(config),
     workspaceId: config.workspace,
-    timeout: 8000,
+    timeout: timeoutMs,
     maxRetries: 1,
   };
 }

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -225,8 +225,13 @@ export async function handlePostToolUse(): Promise<void> {
   // INSTANT: Update local claude context file (~2ms)
   appendClaudeWork(summary);
 
-  // Upload to Honcho and wait for completion
-  await logToHonchoAsync(config, cwd, summary).catch((e) => logHook("post-tool-use", `Upload failed: ${e}`, { error: String(e) }));
+  // Tool calls are intentionally NOT uploaded to Honcho (2026-05-29, per Sam):
+  // the "[Tool] Ran: ..." messages polluted the corpus and skewed distillation
+  // (a single infra-heavy session reshaped the whole representation). Local
+  // work-context above is kept; conversation turns still flow via the stop hook.
+  // To re-enable, uncomment the call below.
+  // await logToHonchoAsync(config, cwd, summary).catch((e) => logHook("post-tool-use", `Upload failed: ${e}`, { error: String(e) }));
+  void logToHonchoAsync; // keep referenced to avoid unused-symbol lints
 
   process.exit(0);
 }

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -106,13 +106,15 @@ export async function handleSessionStart(): Promise<void> {
     setCachedSessionId(cwd, sessionName, session.id, claudeInstanceId);
 
     // Step 4: Add peers to session (materializes session server-side).
-    // Peer defaults (observeMe, observeOthers) are managed server-side —
-    // configure them via API or on app.honcho.dev. We only override observeOthers
-    // for the AI peer in directional mode so it can observe the user.
+    // The AI peer is added with observeMe:false so Honcho never builds a representation
+    // OF the assistant. Otherwise every assistant turn gets distilled into claude->claude
+    // self-observations — noise that is never queried (injection/dialectic only read the
+    // user peer) and which dominated the store (~97% of conclusions). In directional mode
+    // the AI peer still observeOthers:true so it can observe the user.
     const observationMode = getObservationMode(config);
     const peers: Parameters<typeof session.addPeers>[0] = observationMode === "directional"
-      ? [userPeer, [aiPeer, { observeOthers: true }]]
-      : [userPeer, aiPeer];
+      ? [userPeer, [aiPeer, { observeOthers: true, observeMe: false }]]
+      : [userPeer, [aiPeer, { observeMe: false }]];
     await session.addPeers(peers);
 
     // Only persist session names for per-directory strategy (stable names).

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -106,15 +106,13 @@ export async function handleSessionStart(): Promise<void> {
     setCachedSessionId(cwd, sessionName, session.id, claudeInstanceId);
 
     // Step 4: Add peers to session (materializes session server-side).
-    // The AI peer is added with observeMe:false so Honcho never builds a representation
-    // OF the assistant. Otherwise every assistant turn gets distilled into claude->claude
-    // self-observations — noise that is never queried (injection/dialectic only read the
-    // user peer) and which dominated the store (~97% of conclusions). In directional mode
-    // the AI peer still observeOthers:true so it can observe the user.
+    // Peer defaults (observeMe, observeOthers) are managed server-side —
+    // configure them via API or on app.honcho.dev. We only override observeOthers
+    // for the AI peer in directional mode so it can observe the user.
     const observationMode = getObservationMode(config);
     const peers: Parameters<typeof session.addPeers>[0] = observationMode === "directional"
-      ? [userPeer, [aiPeer, { observeOthers: true, observeMe: false }]]
-      : [userPeer, [aiPeer, { observeMe: false }]];
+      ? [userPeer, [aiPeer, { observeOthers: true }]]
+      : [userPeer, aiPeer];
     await session.addPeers(peers);
 
     // Only persist session names for per-directory strategy (stable names).

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -225,7 +225,7 @@ async function fetchFreshContext(config: any, prompt: string): Promise<{ context
         ...(contextTarget ? { target: contextTarget } : {}),
         searchQuery,
         searchTopK: 5,
-        searchMaxDistance: 0.7,
+        searchMaxDistance: 0.85,
         maxConclusions: 15,
         includeMostFrequent: true,
       });

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -807,11 +807,13 @@ export async function runMcpServer(): Promise<void> {
           const query = args?.query as string;
           const reasoningLevel = (args?.reasoning_level as string) ?? config.reasoningLevel ?? "medium";
 
-          // Dialectic genuinely takes ~5-8s server-side; the global 8s client cap leaves
-          // no headroom and causes intermittent timeouts. Give this one call a longer
+          // Dialectic genuinely takes tens of seconds server-side at high/max reasoning
+          // (a multi-step agentic tool loop + a large synthesis write). The global 8s
+          // client cap leaves no headroom and causes intermittent timeouts; even 30s
+          // was tripped by deep-recall queries (~41s observed). Give this one call a 60s
           // ceiling via a dedicated client. Other paths keep fast-fail, and the prompt-
           // injection path has its own 4s race, so prompt latency is unaffected.
-          const chatHoncho = new Honcho(getHonchoClientOptions(config, 30000));
+          const chatHoncho = new Honcho(getHonchoClientOptions(config, 60000));
           const chatPeer = await chatHoncho.peer(
             observationMode === "unified" ? config.peerName : config.aiPeer
           );

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -807,9 +807,19 @@ export async function runMcpServer(): Promise<void> {
           const query = args?.query as string;
           const reasoningLevel = (args?.reasoning_level as string) ?? config.reasoningLevel ?? "medium";
 
-          const response = await activePeer.chat(query, {
+          // Dialectic genuinely takes ~5-8s server-side; the global 8s client cap leaves
+          // no headroom and causes intermittent timeouts. Give this one call a longer
+          // ceiling via a dedicated client. Other paths keep fast-fail, and the prompt-
+          // injection path has its own 4s race, so prompt latency is unaffected.
+          const chatHoncho = new Honcho(getHonchoClientOptions(config, 30000));
+          const chatPeer = await chatHoncho.peer(
+            observationMode === "unified" ? config.peerName : config.aiPeer
+          );
+          const chatSession = await chatHoncho.session(sessionName);
+
+          const response = await chatPeer.chat(query, {
             ...(chatTarget ? { target: chatTarget } : {}),
-            session,
+            session: chatSession,
             reasoningLevel,
           });
 


### PR DESCRIPTION
## Why

The dialectic `chat` tool runs a multi-step agentic tool loop and then a large synthesis write. At `high`/`max` reasoning that legitimately takes tens of seconds — a deep-recall query was observed at **~41s**, which tripped the existing **30s** dedicated client cap and surfaced as `Request timed out`.

## Change

`server.ts` chat handler: `getHonchoClientOptions(config, 30000)` → `60000`.

Scope is just the interactive `chat` tool. Hooks keep their own fast-fail timeouts (the prompt-injection path has a 4s race), so session-start / user-prompt latency is unaffected.

## Context

Server-side, the common path is already fast (deriver→Haiku, synthesis→Haiku on minimal/low/medium per homelab #146). `high`/`max` stay on Sonnet by design, so this ceiling covers the genuinely-slow deep path rather than masking a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added support for configurable timeout settings in API operations, enabling greater control over request behavior
  * Enhanced semantic search parameters for more accurate context retrieval
  * Improved timeout handling for chat operations during complex reasoning tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->