### PR TITLE
Quote ${CLAUDE_PLUGIN_ROOT} in hook commands (fixes hooks on paths with spaces)

### DIFF
--- a/plugins/honcho/hooks/hooks.json
+++ b/plugins/honcho/hooks/hooks.json
@@ -11,7 +11,7 @@
           },
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts\"",
             "timeout": 30000,
             "async": true
           }
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/session-end.ts\"",
             "timeout": 30000
           }
         ]
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/post-tool-use.ts\"",
             "timeout": 10000
           }
         ]
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-tool-honcho.ts\"",
             "timeout": 4000
           }
         ]
@@ -58,7 +58,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/user-prompt.ts\"",
             "timeout": 7000
           }
         ]
@@ -70,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts\"",
             "timeout": 20000
           }
         ]
@@ -80,7 +80,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/pre-compact.ts\"",
             "timeout": 20000
           }
         ]
@@ -91,7 +91,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts",
+            "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/stop.ts\"",
             "timeout": 10000
           }
         ]


### PR DESCRIPTION
Fixes #61.

The `bun run` hook commands in `plugins/honcho/hooks/hooks.json` reference `${CLAUDE_PLUGIN_ROOT}` **unquoted**, so the shell word-splits the path when it contains a space. On macOS the default Claude Desktop plugin location is under `~/Library/Application Support/Claude/…` (note the space), so the hooks silently fail to fire for that install class — no Honcho capture, often a confusing/empty error.

This wraps `${CLAUDE_PLUGIN_ROOT}` in double quotes on all 8 commands, matching the `check-version.sh` command which was already quoted. No behavior change for space-free paths.

```json
- "command": "bun run ${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts"
+ "command": "bun run \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.ts\""
```

JSON validated after the change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook command execution by properly formatting script paths in configuration to ensure reliable invocation across multiple hooks (SessionStart, SessionEnd, PostToolUse, PreToolUse, UserPromptSubmit, PreCompact, and Stop).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->