### PR TITLE
fix(mcp): use v2 Message fields (peerId/createdAt) in search results

### DIFF
--- a/plugins/honcho/bun.lock
+++ b/plugins/honcho/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-honcho",
       "dependencies": {
-        "@honcho-ai/sdk": "^2.1.0",
+        "@honcho-ai/sdk": "^2.1.1",
         "@modelcontextprotocol/sdk": "^1.26.0",
       },
       "devDependencies": {
@@ -15,7 +15,7 @@
     },
   },
   "packages": {
-    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.1.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-GPyeKTDRhg5jd77RAh63LwrxLxnbluLdYUF1gsI6g6CU4eTyv8s1+KJ3/OTCiBwJ/dhjznNvQUngkUjjnNzUTA=="],
+    "@honcho-ai/sdk": ["@honcho-ai/sdk@2.2.0", "", { "dependencies": { "zod": "4.0.0" } }, "sha512-SyygN+BrpUB2fRjhwcYmT+tcEhHrKmbj9nOZLVUFY7M5YBswJ+mZb/CeLpNbRh+QQTU8F8JWY3lQat95c6nwmA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/README.md
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/README.md
@@ -1,6 +1,6 @@
 # Honcho TypeScript SDK
 
-A high-level, ergonomic TypeScript SDK for the Honcho conversational memory platform. This library wraps [honcho-node-core](../honcho-node-core) to provide a user-friendly, Pythonic API for managing peers, sessions, and conversational context.
+A high-level, ergonomic TypeScript SDK for the Honcho conversational memory platform. Provides a user-friendly API for managing peers, sessions, and conversational context.
 
 ## Installation
 
@@ -19,12 +19,12 @@ const honcho = new Honcho({
   workspaceId: "test",
 });
 
-const assistant = honcho.peer("bob");
-const alice = honcho.peer("alice");
+const assistant = await honcho.peer("bob");
+const alice = await honcho.peer("alice");
 
-await honcho.getPeers();
+await honcho.peers();
 
-const session = honcho.session("session_1");
+const session = await honcho.session("session_1");
 await session.addPeers([alice, assistant]);
 
 await session.addMessages([

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/client.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/client.d.ts
@@ -4,7 +4,7 @@ import { Page } from './pagination';
 import { Peer } from './peer';
 import { Session } from './session';
 import type { PeerResponse, QueueStatus, SessionResponse, WorkspaceResponse } from './types/api';
-import { type Filters, type HonchoConfig, type PeerConfig, type PeerMetadata, type QueueStatusOptions, type SessionConfig, type SessionMetadata, type WorkspaceConfig, type WorkspaceMetadata } from './validation';
+import { type Filters, type HonchoConfig, type PeerAddition, type PeerConfig, type PeerMetadata, type QueueStatusOptions, type SessionConfig, type SessionMetadata, type WorkspaceConfig, type WorkspaceMetadata } from './validation';
 /**
  * Main client for the Honcho TypeScript SDK.
  *
@@ -131,7 +131,7 @@ export declare class Honcho {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of Peer objects representing all peers in the workspace
      */
     peers(options?: Filters | {
@@ -153,10 +153,13 @@ export declare class Honcho {
      * @param id - Unique identifier for the session within the workspace. Should be a
      *             stable identifier that can be used consistently to reference the
      *             same conversation
-     * @param metadata - Optional metadata dictionary to associate with this session.
+     * @param options.metadata - Optional metadata dictionary to associate with this session.
      *                   If set, will get/create session immediately with metadata.
-     * @param configuration - Optional configuration to set for this session.
+     * @param options.configuration - Optional configuration to set for this session.
      *                        If set, will get/create session immediately with flags.
+     * @param options.peers - Optional peers to attach to the session at creation.
+     *                Accepts the same shape as `session.addPeers()` (peer ID strings,
+     *                Peer objects, arrays of either, or a record with per-peer config).
      * @returns Promise resolving to a Session object that can be used to add peers,
      *          send messages, and manage conversation context
      * @throws Error if the session ID is empty or invalid
@@ -164,6 +167,7 @@ export declare class Honcho {
     session(id: string, options?: {
         metadata?: SessionMetadata;
         configuration?: SessionConfig;
+        peers?: PeerAddition;
     }): Promise<Session>;
     /**
      * Get all sessions in the current workspace.
@@ -173,7 +177,7 @@ export declare class Honcho {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of Session objects representing all sessions
      *          in the workspace. Returns an empty page if no sessions exist
      */
@@ -242,8 +246,8 @@ export declare class Honcho {
      * user has access to.
      *
      * @param options - Either a legacy raw filter object or an options object with
-     *                  `filters`, `page`, and `size`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  `filters`, `page`, `size`, and `reverse`. See
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of workspace ID strings. Returns an empty
      *          page if no workspaces are accessible or none exist
      */
@@ -251,6 +255,7 @@ export declare class Honcho {
         filters?: Filters;
         page?: number;
         size?: number;
+        reverse?: boolean;
     }): Promise<Page<string, WorkspaceResponse>>;
     /**
      * Delete a workspace.
@@ -267,7 +272,7 @@ export declare class Honcho {
      * Makes an API call to search for messages in the current workspace.
      *
      * @param query - The search query to use
-     * @param filters - Optional filters to scope the search. See [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     * @param filters - Optional filters to scope the search. See [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param limit - Number of results to return (1-100, default: 10).
      * @returns Promise resolving to an array of Message objects representing the search results.
      *          Returns an empty array if no messages are found.

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/client.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/client.js
@@ -147,6 +147,7 @@ class Honcho {
             query: {
                 page: params?.page,
                 size: params?.size,
+                reverse: params?.reverse ? 'true' : undefined,
             },
         });
     }
@@ -192,6 +193,7 @@ class Honcho {
                 id: params.id,
                 metadata: params.metadata,
                 configuration: (0, validation_1.sessionConfigToApi)(params.configuration),
+                peers: params.peers,
             },
         });
     }
@@ -242,7 +244,7 @@ class Honcho {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of Peer objects representing all peers in the workspace
      */
     async peers(options) {
@@ -286,10 +288,13 @@ class Honcho {
      * @param id - Unique identifier for the session within the workspace. Should be a
      *             stable identifier that can be used consistently to reference the
      *             same conversation
-     * @param metadata - Optional metadata dictionary to associate with this session.
+     * @param options.metadata - Optional metadata dictionary to associate with this session.
      *                   If set, will get/create session immediately with metadata.
-     * @param configuration - Optional configuration to set for this session.
+     * @param options.configuration - Optional configuration to set for this session.
      *                        If set, will get/create session immediately with flags.
+     * @param options.peers - Optional peers to attach to the session at creation.
+     *                Accepts the same shape as `session.addPeers()` (peer ID strings,
+     *                Peer objects, arrays of either, or a record with per-peer config).
      * @returns Promise resolving to a Session object that can be used to add peers,
      *          send messages, and manage conversation context
      * @throws Error if the session ID is empty or invalid
@@ -303,10 +308,14 @@ class Honcho {
         const validatedConfiguration = options?.configuration
             ? validation_1.SessionConfigSchema.parse(options.configuration)
             : undefined;
+        const validatedPeers = options?.peers !== undefined
+            ? validation_1.PeerAdditionToApiSchema.parse(options.peers)
+            : undefined;
         const sessionData = await this._getOrCreateSession(this.workspaceId, {
             id: validatedId,
             configuration: validatedConfiguration,
             metadata: validatedMetadata,
+            peers: validatedPeers,
         });
         return new session_1.Session(validatedId, this.workspaceId, this._http, sessionData.metadata ?? undefined, (0, validation_1.sessionConfigFromApi)(sessionData.configuration) ?? undefined, () => this._ensureWorkspace(), sessionData.created_at, sessionData.is_active);
     }
@@ -318,7 +327,7 @@ class Honcho {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of Session objects representing all sessions
      *          in the workspace. Returns an empty page if no sessions exist
      */
@@ -438,8 +447,8 @@ class Honcho {
      * user has access to.
      *
      * @param options - Either a legacy raw filter object or an options object with
-     *                  `filters`, `page`, and `size`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  `filters`, `page`, `size`, and `reverse`. See
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a Page of workspace ID strings. Returns an empty
      *          page if no workspaces are accessible or none exist
      */
@@ -448,20 +457,24 @@ class Honcho {
             'filters',
             'page',
             'size',
+            'reverse',
         ]);
         const validatedFilter = normalizedOptions.filters
             ? validation_1.FilterSchema.parse(normalizedOptions.filters)
             : undefined;
+        const reverse = normalizedOptions.reverse;
         const workspacesPage = await this._listWorkspaces({
             filters: validatedFilter,
             page: normalizedOptions.page,
             size: normalizedOptions.size,
+            reverse,
         });
         const fetchNextPage = async (page, size) => {
             return this._listWorkspaces({
                 filters: validatedFilter,
                 page,
                 size,
+                reverse,
             });
         };
         return new pagination_1.Page(workspacesPage, (workspace) => workspace.id, fetchNextPage);
@@ -483,7 +496,7 @@ class Honcho {
      * Makes an API call to search for messages in the current workspace.
      *
      * @param query - The search query to use
-     * @param filters - Optional filters to scope the search. See [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     * @param filters - Optional filters to scope the search. See [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param limit - Number of results to return (1-100, default: 10).
      * @returns Promise resolving to an array of Message objects representing the search results.
      *          Returns an empty array if no messages are found.

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/conclusions.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/conclusions.d.ts
@@ -1,7 +1,7 @@
 import type { HonchoHTTPClient } from './http/client';
 import { Page } from './pagination';
 import type { Session } from './session';
-import type { ConclusionResponse, RepresentationOptions } from './types/api';
+import type { ConclusionLevel, ConclusionResponse, RepresentationOptions } from './types/api';
 /**
  * Parameters for creating a conclusion.
  */
@@ -23,8 +23,14 @@ export declare class Conclusion {
     readonly observerId: string;
     readonly observedId: string;
     readonly sessionId: string | null;
+    /**
+     * Reasoning level: 'explicit' conclusions are extracted directly from
+     * messages; 'deductive'/'inductive'/'contradiction' are derived during
+     * dreaming.
+     */
+    readonly level: ConclusionLevel;
     readonly createdAt: string;
-    constructor(id: string, content: string, observerId: string, observedId: string, sessionId: string | null, createdAt: string);
+    constructor(id: string, content: string, observerId: string, observedId: string, sessionId: string | null, createdAt: string, level?: ConclusionLevel);
     static fromApiResponse(data: ConclusionResponse): Conclusion;
     toString(): string;
 }
@@ -50,18 +56,34 @@ export declare class ConclusionScope {
      * @param options.page - Page number (1-indexed, default: 1)
      * @param options.size - Number of items per page (default: 50)
      * @param options.session - Optional session (ID string or Session object) to filter by
+     * @param options.filters - Optional additional filter criteria, merged with
+     *   this scope's observer/observed (and session, if given). Supports the same
+     *   operators as other list endpoints — e.g. `{ level: 'explicit' }` to get
+     *   only conclusions extracted directly from messages (i.e. not derived during
+     *   dreaming). See
+     *   https://honcho.dev/docs/v3/documentation/features/advanced/using-filters
      * @returns Promise resolving to a Page of Conclusion objects
      */
     list(options?: {
         page?: number;
         size?: number;
         session?: string | Session;
+        filters?: Record<string, unknown>;
         reverse?: boolean;
     }): Promise<Page<Conclusion, ConclusionResponse>>;
     /**
      * Semantic search for conclusions in this scope.
+     *
+     * @param query - The search query string
+     * @param topK - Maximum number of results to return (default: 10)
+     * @param distance - Maximum cosine distance threshold (0.0-1.0)
+     * @param filters - Optional additional filter criteria, merged with this
+     *   scope's observer/observed. Supports the same operators as the list
+     *   endpoint — e.g. `{ level: 'deductive' }` to search only conclusions
+     *   derived during dreaming. See
+     *   https://honcho.dev/docs/v3/documentation/features/advanced/using-filters
      */
-    query(query: string, topK?: number, distance?: number): Promise<Conclusion[]>;
+    query(query: string, topK?: number, distance?: number, filters?: Record<string, unknown>): Promise<Conclusion[]>;
     /**
      * Delete a conclusion by ID.
      */

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/conclusions.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/conclusions.js
@@ -5,22 +5,53 @@ const api_version_1 = require("./api-version");
 const pagination_1 = require("./pagination");
 const validation_1 = require("./validation");
 /**
+ * Filter keys that define a conclusion scope (the observer/observed peer pair).
+ * They are set from the scope itself, so a caller must not pass them in `filters`.
+ */
+const SCOPE_RESERVED_KEYS = [
+    'observer',
+    'observed',
+    'observer_id',
+    'observed_id',
+];
+/**
+ * Throw if `filters` contains keys managed by the conclusion scope.
+ *
+ * The observer/observed peer pair (and, on `list`, the session) is fixed by the
+ * scope, so letting a user filter override it would silently return data from a
+ * different scope than requested. Fail loud instead.
+ */
+function rejectReservedFilterKeys(filters, reserved) {
+    if (!filters)
+        return;
+    const clash = reserved.filter((k) => k in filters).sort();
+    if (clash.length > 0) {
+        let guidance = 'Choose the peer pair via peer.conclusions / peer.conclusionsOf(target)';
+        if (reserved.includes('session') || reserved.includes('session_id')) {
+            guidance += '; use the session option to filter by session';
+        }
+        throw new Error(`Filter key(s) ${clash.join(', ')} are managed by this conclusion scope ` +
+            `and cannot be passed in filters. ${guidance}.`);
+    }
+}
+/**
  * A conclusion from Honcho's reasoning system.
  *
  * Conclusions are facts derived from messages that help build a representation
  * of a peer.
  */
 class Conclusion {
-    constructor(id, content, observerId, observedId, sessionId, createdAt) {
+    constructor(id, content, observerId, observedId, sessionId, createdAt, level = 'explicit') {
         this.id = id;
         this.content = content;
         this.observerId = observerId;
         this.observedId = observedId;
         this.sessionId = sessionId;
+        this.level = level;
         this.createdAt = createdAt;
     }
     static fromApiResponse(data) {
-        return new Conclusion(data.id, data.content, data.observer_id, data.observed_id, data.session_id, data.created_at);
+        return new Conclusion(data.id, data.content, data.observer_id, data.observed_id, data.session_id, data.created_at, data.level);
     }
     toString() {
         const truncatedContent = this.content.length > 50
@@ -81,9 +112,20 @@ class ConclusionScope {
      * @param options.page - Page number (1-indexed, default: 1)
      * @param options.size - Number of items per page (default: 50)
      * @param options.session - Optional session (ID string or Session object) to filter by
+     * @param options.filters - Optional additional filter criteria, merged with
+     *   this scope's observer/observed (and session, if given). Supports the same
+     *   operators as other list endpoints — e.g. `{ level: 'explicit' }` to get
+     *   only conclusions extracted directly from messages (i.e. not derived during
+     *   dreaming). See
+     *   https://honcho.dev/docs/v3/documentation/features/advanced/using-filters
      * @returns Promise resolving to a Page of Conclusion objects
      */
     async list(options) {
+        rejectReservedFilterKeys(options?.filters, [
+            ...SCOPE_RESERVED_KEYS,
+            'session',
+            'session_id',
+        ]);
         const resolvedSessionId = options?.session
             ? typeof options.session === 'string'
                 ? options.session
@@ -92,10 +134,9 @@ class ConclusionScope {
         const filters = {
             observer_id: this.observer,
             observed_id: this.observed,
+            ...(resolvedSessionId ? { session_id: resolvedSessionId } : {}),
+            ...options?.filters,
         };
-        if (resolvedSessionId) {
-            filters.session_id = resolvedSessionId;
-        }
         const reverse = options?.reverse;
         const response = await this._list({
             filters,
@@ -110,17 +151,27 @@ class ConclusionScope {
     }
     /**
      * Semantic search for conclusions in this scope.
+     *
+     * @param query - The search query string
+     * @param topK - Maximum number of results to return (default: 10)
+     * @param distance - Maximum cosine distance threshold (0.0-1.0)
+     * @param filters - Optional additional filter criteria, merged with this
+     *   scope's observer/observed. Supports the same operators as the list
+     *   endpoint — e.g. `{ level: 'deductive' }` to search only conclusions
+     *   derived during dreaming. See
+     *   https://honcho.dev/docs/v3/documentation/features/advanced/using-filters
      */
-    async query(query, topK = 10, distance) {
-        const filters = {
-            observer_id: this.observer,
-            observed_id: this.observed,
-        };
+    async query(query, topK = 10, distance, filters) {
+        rejectReservedFilterKeys(filters, SCOPE_RESERVED_KEYS);
         const response = await this._query({
             query,
             top_k: topK,
             distance,
-            filters,
+            filters: {
+                observer_id: this.observer,
+                observed_id: this.observed,
+                ...filters,
+            },
         });
         return (response ?? []).map((item) => Conclusion.fromApiResponse(item));
     }

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/http/client.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/http/client.js
@@ -80,17 +80,6 @@ class HonchoHTTPClient {
                     error instanceof errors_1.ConnectionError) {
                     throw error;
                 }
-                // Handle fetch errors (network issues)
-                if (error instanceof TypeError && error.message.includes('fetch')) {
-                    const connError = new errors_1.ConnectionError(error.message);
-                    if (attempt < this.maxRetries) {
-                        lastError = connError;
-                        await this.sleep(this.getRetryDelay(attempt));
-                        attempt++;
-                        continue;
-                    }
-                    throw connError;
-                }
                 throw error;
             }
         }
@@ -217,6 +206,14 @@ class HonchoHTTPClient {
         catch (error) {
             if (error instanceof DOMException && error.name === 'AbortError') {
                 throw new errors_1.TimeoutError(`Request timed out after ${timeout}ms`);
+            }
+            // fetch() throws TypeError for network-level failures (e.g. "fetch
+            // failed", connection reset, DNS errors). Convert these to
+            // ConnectionError so the retry loop can handle them. This mapping
+            // lives here rather than in the outer catch so that TypeErrors from
+            // other sources (e.g. JSON.stringify serialization) propagate as-is.
+            if (error instanceof TypeError) {
+                throw new errors_1.ConnectionError(error.message);
             }
             throw error;
         }

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/index.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/index.d.ts
@@ -7,5 +7,5 @@ export { Page } from './pagination';
 export { Peer, PeerContext } from './peer';
 export { Session } from './session';
 export { SessionContext, SessionSummaries, Summary, type SummaryData, } from './session_context';
-export type { ConclusionQueryParams, ConclusionResponse, MessageResponse, PageResponse, PeerContextResponse, PeerResponse, QueueStatus, QueueStatusResponse, RepresentationOptions, SessionContextResponse, SessionQueueStatus, SessionResponse, SessionSummariesResponse, SummaryResponse, WorkspaceResponse, } from './types/api';
+export type { ConclusionLevel, ConclusionQueryParams, ConclusionResponse, MessageResponse, PageResponse, PeerContextResponse, PeerResponse, QueueStatus, QueueStatusResponse, RepresentationOptions, SessionContextResponse, SessionQueueStatus, SessionResponse, SessionSummariesResponse, SummaryResponse, WorkspaceResponse, } from './types/api';
 export type { ChatQuery, ContextParams, FileUpload, Filters, GetRepresentationParams, HonchoConfig, MessageAddition, PeerAddition, PeerConfig, PeerGetRepresentationParams, PeerMetadata, PeerRemoval, QueueStatusOptions, SessionConfig, SessionMetadata, SessionPeerConfig, WorkspaceConfig, WorkspaceMetadata, } from './validation';

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/peer.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/peer.d.ts
@@ -187,7 +187,7 @@ export declare class Peer {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a paginated list of Session objects this peer belongs to.
      *          Returns an empty list if the peer is not a member of any sessions
      */
@@ -288,7 +288,7 @@ export declare class Peer {
      * Makes an API call to search endpoint.
      *
      * @param query The search query to use
-     * @param filters - Optional filters to scope the search. See [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     * @param filters - Optional filters to scope the search. See [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param limit - Optional limit on the number of results to return.
      * @returns Promise resolving to an array of Message objects representing the search results.
      *          Returns an empty array if no messages are found.

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/peer.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/peer.js
@@ -268,7 +268,7 @@ class Peer {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a paginated list of Session objects this peer belongs to.
      *          Returns an empty list if the peer is not a member of any sessions
      */
@@ -427,7 +427,7 @@ class Peer {
      * Makes an API call to search endpoint.
      *
      * @param query The search query to use
-     * @param filters - Optional filters to scope the search. See [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     * @param filters - Optional filters to scope the search. See [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param limit - Optional limit on the number of results to return.
      * @returns Promise resolving to an array of Message objects representing the search results.
      *          Returns an empty array if no messages are found.

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/session.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/session.d.ts
@@ -203,7 +203,7 @@ export declare class Session {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a paginated Page of Message objects
      */
     messages(options?: Filters | {
@@ -332,7 +332,7 @@ export declare class Session {
      * @param query - The search query to use
      * @param options - Search options
      * @param options.filters - Optional filters to scope the search. See
-     *                          [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                          [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param options.limit - Number of results to return (1-100, default: 10)
      * @returns Promise resolving to an array of Message objects matching the query
      */

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/session.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/session.js
@@ -349,7 +349,7 @@ class Session {
      *
      * @param options - Either a legacy raw filter object or an options object with
      *                  `filters`, `page`, `size`, and `reverse`. See
-     *                  [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                  [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @returns Promise resolving to a paginated Page of Message objects
      */
     async messages(options) {
@@ -553,7 +553,7 @@ class Session {
      * @param query - The search query to use
      * @param options - Search options
      * @param options.filters - Optional filters to scope the search. See
-     *                          [search filters documentation](https://docs.honcho.dev/v3/documentation/core-concepts/features/using-filters).
+     *                          [search filters documentation](https://honcho.dev/docs/v3/documentation/core-concepts/features/using-filters).
      * @param options.limit - Number of results to return (1-100, default: 10)
      * @returns Promise resolving to an array of Message objects matching the query
      */

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/types/api.d.ts
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/types/api.d.ts
@@ -22,6 +22,7 @@ export interface WorkspaceListParams {
     filters?: Record<string, unknown>;
     page?: number;
     size?: number;
+    reverse?: boolean;
 }
 export interface PeerResponse {
     id: string;
@@ -43,6 +44,7 @@ export interface PeerListParams {
     filters?: Record<string, unknown>;
     page?: number;
     size?: number;
+    reverse?: boolean;
 }
 export interface PeerChatParams {
     query: string;
@@ -105,6 +107,7 @@ export interface SessionListParams {
     filters?: Record<string, unknown>;
     page?: number;
     size?: number;
+    reverse?: boolean;
 }
 export interface SessionCloneParams {
     message_id?: string;
@@ -175,18 +178,25 @@ export interface MessageListParams {
     filters?: Record<string, unknown>;
     page?: number;
     size?: number;
+    reverse?: boolean;
 }
 export interface MessageSearchParams {
     query: string;
     filters?: Record<string, unknown>;
     limit?: number;
 }
+/**
+ * Reasoning level of a conclusion. "explicit" conclusions are extracted
+ * directly from messages; the others are derived during dreaming.
+ */
+export type ConclusionLevel = 'explicit' | 'deductive' | 'inductive' | 'contradiction';
 export interface ConclusionResponse {
     id: string;
     content: string;
     observer_id: string;
     observed_id: string;
     session_id: string | null;
+    level: ConclusionLevel;
     created_at: string;
 }
 export interface ConclusionCreateParams {
@@ -202,6 +212,7 @@ export interface ConclusionListParams {
     filters?: Record<string, unknown>;
     page?: number;
     size?: number;
+    reverse?: boolean;
 }
 export interface ConclusionQueryParams {
     query: string;

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/dist/validation.js
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/dist/validation.js
@@ -25,7 +25,7 @@ exports.WorkspaceIdSchema = zod_1.z
     .string()
     .min(1, 'Workspace ID must be a non-empty string')
     .regex(/^[a-zA-Z0-9_-]+$/, 'Workspace ID may only contain letters, numbers, underscores, and hyphens')
-    .max(100, 'Workspace ID can be at most 100 characters');
+    .max(512, 'Workspace ID can be at most 512 characters');
 /**
  * Schema for Honcho client configuration options.
  */
@@ -70,7 +70,7 @@ exports.PeerIdSchema = zod_1.z
     .string()
     .min(1, 'Peer ID must be a non-empty string')
     .regex(/^[a-zA-Z0-9_-]+$/, 'Peer ID may only contain letters, numbers, underscores, and hyphens')
-    .max(100, 'Peer ID can be at most 100 characters');
+    .max(512, 'Peer ID can be at most 512 characters');
 /**
  * Strict helper: peer ID as object.
  */
@@ -141,7 +141,7 @@ exports.SessionIdSchema = zod_1.z
     .string()
     .min(1, 'Session ID must be a non-empty string')
     .regex(/^[a-zA-Z0-9_-]+$/, 'Session ID may only contain letters, numbers, underscores, and hyphens')
-    .max(100, 'Session ID can be at most 100 characters');
+    .max(512, 'Session ID can be at most 512 characters');
 /**
  * Strict helper: session ID as object.
  */

--- a/plugins/honcho/node_modules/@honcho-ai/sdk/package.json
+++ b/plugins/honcho/node_modules/@honcho-ai/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@honcho-ai/sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Official DX Optimized TypeScript SDK for Honcho",
   "author": "Plastic Labs <hello@plasticlabs.ai>",
   "license": "Apache-2.0",

--- a/plugins/honcho/package.json
+++ b/plugins/honcho/package.json
@@ -15,7 +15,7 @@
   "author": "Plastic Labs",
   "license": "MIT",
   "dependencies": {
-    "@honcho-ai/sdk": "^2.1.0",
+    "@honcho-ai/sdk": "^2.1.1",
     "@modelcontextprotocol/sdk": "^1.26.0"
   },
   "devDependencies": {

--- a/plugins/honcho/src/mcp/server.ts
+++ b/plugins/honcho/src/mcp/server.ts
@@ -825,10 +825,10 @@ export async function runMcpServer(): Promise<void> {
             ? await honcho.search(query, { limit })
             : await session.search(query, { limit });
 
-          const results = messages.map((msg: any) => ({
+          const results = messages.map((msg) => ({
             content: msg.content,
-            peerId: msg.peer,
-            createdAt: msg.createdAt || msg.created_at,
+            peerId: msg.peerId,
+            createdAt: msg.createdAt,
           }));
 
           return {


### PR DESCRIPTION
## What

Two related changes:

1. **fix(mcp):** the MCP `search` tool maps Honcho `search()` results but reads `msg.peer` / `msg.created_at` — fields that don't exist on the v2 SDK's `Message` class (`peerId` / `createdAt`). Every search result silently returned `peerId: undefined`. Dropped the `any` cast so `msg` is typed as `Message` and the compiler catches this going forward.

2. **chore(deps):** raise the `@honcho-ai/sdk` floor to `^2.1.1` (the version the SDK docs cite as required for Honcho 3.0.0+) and update the vendored `@honcho-ai/sdk` tree to the current resolved `2.2.0`, plus its `bun.lock` entry. **Only** `@honcho-ai/sdk` is touched — no other vendored packages.

```ts
// before
const results = messages.map((msg: any) => ({
  content: msg.content,
  peerId: msg.peer,                            // undefined
  createdAt: msg.createdAt || msg.created_at,  // dead fallback
}));

// after
const results = messages.map((msg) => ({
  content: msg.content,
  peerId: msg.peerId,
  createdAt: msg.createdAt,
}));
```

## Testing

`bunx tsc --noEmit` passes; `bun install --frozen-lockfile` is consistent (package.json `^2.1.1` ↔ lockfile, resolved `2.2.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)