### PR TITLE
Add generic per-session admissionCommand policy hook

### DIFF
--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -678,9 +678,11 @@ export function isPluginEnabled(): boolean {
  * not silently fall back to "capture everything"; that would defeat the
  * purpose of having a policy at all.
  *
- * Callers (each of the four capture hooks) must call this BEFORE any
- * `honcho.session(...)`, `session.addPeers(...)`, or `session.addMessages(...)`
- * call, so a rejected session never touches the Honcho API.
+ * Callers (each of the six write/create hooks: session-start, post-tool-use,
+ * user-prompt, stop, session-end, pre-compact) must call this BEFORE any
+ * `honcho.session(...)`, `honcho.peer(...)`, `session.addPeers(...)`,
+ * `session.addMessages(...)`, `peer.chat(...)`, or any other Honcho API
+ * contact, so a rejected session never touches the Honcho API.
  */
 export function isAdmitted(hookInput: unknown): boolean {
   const config = loadConfig();

--- a/plugins/honcho/src/config.ts
+++ b/plugins/honcho/src/config.ts
@@ -1,6 +1,7 @@
 import { homedir } from "os";
 import { join, basename } from "path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { spawnSync } from "child_process";
 import { captureGitState } from "./git.js";
 import { getInstanceIdForCwd, getClaudeInstanceId } from "./cache.js";
 
@@ -90,6 +91,8 @@ export interface HostConfig {
   contextRefresh?: ContextRefreshConfig;
   localContext?: LocalContextConfig;
   endpoint?: HonchoEndpointConfig;
+  /** Per-host override for the external admission policy command (see root field of the same name). */
+  admissionCommand?: string;
 }
 
 let _detectedHost: HonchoHost | null = null;
@@ -191,6 +194,13 @@ interface HonchoFileConfig {
    *  ignoring host-specific blocks. When false (default), each host
    *  uses its own block and flat fields are fallbacks only. */
   globalOverride?: boolean;
+  /** Optional external admission policy. When set, every capture hook
+   *  (session-start, user-prompt, post-tool-use, stop) shells out to this
+   *  command with the hook's HookInput JSON on stdin before creating any
+   *  session/peer or writing any message. Exit 0 admits; non-zero (or a
+   *  spawn error) rejects. Unset (default): every session is admitted,
+   *  matching pre-existing behavior. See isAdmitted(). */
+  admissionCommand?: string;
   // Legacy flat fields (read-only fallbacks when no hosts block)
   cursorPeer?: string;
   claudePeer?: string;
@@ -241,6 +251,8 @@ export interface HonchoCLAUDEConfig {
   logging?: boolean;
   /** When true, flat workspace/aiPeer fields apply to ALL hosts */
   globalOverride?: boolean;
+  /** Optional external admission policy command (see the file-config field of the same name above). */
+  admissionCommand?: string;
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
@@ -348,6 +360,7 @@ function resolveConfig(raw: HonchoFileConfig, host: HonchoHost): HonchoCLAUDECon
     enabled: hostBlock?.enabled ?? raw.enabled,
     logging: hostBlock?.logging ?? raw.logging,
     globalOverride: raw.globalOverride,
+    admissionCommand: hostBlock?.admissionCommand ?? raw.admissionCommand,
   };
 
   return mergeWithEnvVars(config);
@@ -650,6 +663,46 @@ export function isLoggingEnabled(): boolean {
 export function isPluginEnabled(): boolean {
   const config = loadConfig();
   return config?.enabled !== false;
+}
+
+/**
+ * Generic per-session admission policy hook.
+ *
+ * When `admissionCommand` is unset (the default), every session is admitted
+ * -- this is a strict no-op, existing installs see zero behavior change.
+ *
+ * When set, the configured command is spawned with the hook's raw
+ * HookInput JSON written to its stdin. Exit code 0 admits (capture
+ * proceeds); any non-zero exit, or a failure to spawn the command at all,
+ * REJECTS -- fail-closed. A misconfigured or crashing admission policy must
+ * not silently fall back to "capture everything"; that would defeat the
+ * purpose of having a policy at all.
+ *
+ * Callers (each of the four capture hooks) must call this BEFORE any
+ * `honcho.session(...)`, `session.addPeers(...)`, or `session.addMessages(...)`
+ * call, so a rejected session never touches the Honcho API.
+ */
+export function isAdmitted(hookInput: unknown): boolean {
+  const config = loadConfig();
+  const command = config?.admissionCommand;
+  if (!command) {
+    return true;
+  }
+
+  try {
+    const result = spawnSync(command, {
+      input: JSON.stringify(hookInput ?? {}),
+      shell: true,
+      encoding: "utf-8",
+      timeout: 5000,
+    });
+    if (result.error) {
+      return false;
+    }
+    return result.status === 0;
+  } catch {
+    return false;
+  }
 }
 
 export function setPluginEnabled(enabled: boolean): void {

--- a/plugins/honcho/src/hooks/post-tool-use.ts
+++ b/plugins/honcho/src/hooks/post-tool-use.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin } from "../config.js";
 import { appendClaudeWork, getClaudeInstanceId } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
 import { visCapture } from "../visual.js";
@@ -203,6 +203,15 @@ export async function handlePostToolUse(): Promise<void> {
       hookInput = JSON.parse(input);
     }
   } catch {
+    process.exit(0);
+  }
+
+  // Admission gate: see session-start.ts for the contract. Unset = admit all.
+  // NOTE: this hook's local HookInput type does not declare session_id, but
+  // the raw JSON payload from Claude Code's PostToolUse event carries it --
+  // JSON.parse does not strip undeclared fields, so isAdmitted() still sees
+  // it at runtime. Do not "fix" this by stripping fields before the call.
+  if (!isAdmitted(hookInput)) {
     process.exit(0);
   }
 

--- a/plugins/honcho/src/hooks/pre-compact.ts
+++ b/plugins/honcho/src/hooks/pre-compact.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin, getObservationMode } from "../config.js";
 import { Spinner } from "../spinner.js";
 import { setMemoryState } from "../state.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
@@ -105,6 +105,11 @@ export async function handlePreCompact(): Promise<void> {
     }
   } catch {
     // No input, continue with defaults
+  }
+
+  // Admission gate: see session-start.ts for the contract. Unset = admit all.
+  if (!isAdmitted(hookInput)) {
+    process.exit(0);
   }
 
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();

--- a/plugins/honcho/src/hooks/session-end.ts
+++ b/plugins/honcho/src/hooks/session-end.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import {
   getQueuedMessages,
@@ -193,6 +193,11 @@ export async function handleSessionEnd(): Promise<void> {
     }
   } catch {
     // Continue with defaults
+  }
+
+  // Admission gate: see session-start.ts for the contract. Unset = admit all.
+  if (!isAdmitted(hookInput)) {
+    process.exit(0);
   }
 
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();

--- a/plugins/honcho/src/hooks/session-start.ts
+++ b/plugins/honcho/src/hooks/session-start.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionForPath, setSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin, getObservationMode } from "../config.js";
 import {
   setCachedUserContext,
   setCachedSessionId,
@@ -45,6 +45,13 @@ export async function handleSessionStart(): Promise<void> {
     }
   } catch {
     // No input or invalid JSON
+  }
+
+  // Admission gate: an unset admissionCommand admits everything (no-op,
+  // preserves existing behavior). A configured command decides whether
+  // this session is allowed to create/write to Honcho state at all.
+  if (!isAdmitted(hookInput)) {
+    process.exit(0);
   }
 
   const cwd = hookInput.workspace_roots?.[0] || hookInput.cwd || process.cwd();

--- a/plugins/honcho/src/hooks/stop.ts
+++ b/plugins/honcho/src/hooks/stop.ts
@@ -1,5 +1,5 @@
 import { Honcho } from "@honcho-ai/sdk";
-import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin } from "../config.js";
+import { loadConfig, getSessionForPath, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin } from "../config.js";
 import { existsSync, readFileSync } from "fs";
 import { getInstanceIdForCwd } from "../cache.js";
 import { logHook, logApiCall, setLogContext } from "../log.js";
@@ -121,6 +121,11 @@ export async function handleStop(): Promise<void> {
   // If stop_hook_active is true, Claude is already continuing from a previous stop hook
   // Don't process to avoid infinite loops
   if (hookInput.stop_hook_active) {
+    process.exit(0);
+  }
+
+  // Admission gate: see session-start.ts for the contract. Unset = admit all.
+  if (!isAdmitted(hookInput)) {
     process.exit(0);
   }
 

--- a/plugins/honcho/src/hooks/user-prompt.ts
+++ b/plugins/honcho/src/hooks/user-prompt.ts
@@ -1,7 +1,7 @@
 import { Honcho } from "@honcho-ai/sdk";
 import { readFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, getCachedStdin, getObservationMode } from "../config.js";
+import { loadConfig, getSessionName, getHonchoClientOptions, isPluginEnabled, isAdmitted, getCachedStdin, getObservationMode } from "../config.js";
 import {
   getCachedUserContext,
   getStaleCachedUserContext,
@@ -115,6 +115,11 @@ export async function handleUserPrompt(): Promise<void> {
       hookInput = JSON.parse(input);
     }
   } catch {
+    process.exit(0);
+  }
+
+  // Admission gate: see session-start.ts for the contract. Unset = admit all.
+  if (!isAdmitted(hookInput)) {
     process.exit(0);
   }
 


### PR DESCRIPTION
## Why

The four capture hooks (session-start, user-prompt, post-tool-use, stop)
each independently derive a session name from the hook's session_id and
write to Honcho -- with no way for the host application to say "don't
capture this one." Any process that fires these hooks (a subagent, a
headless worker, a CI run, a test harness) accumulates durable memory
state exactly as if it were the primary interactive session.

This is a real problem for any multi-agent or multi-process Claude Code
setup: worker/subagent sessions pollute the same peer/session space as
the agent whose memory is actually meant to be durable, with no built-in
way to tell them apart.

## What this adds

A new optional config key, `admissionCommand` (settable at the root
config level or per-host, same pattern as `enabled`/`logging`/`sessionStrategy`).

- **Unset (default): zero behavior change.** Every session is admitted,
  exactly as today. Existing installs are unaffected.
- **Set:** before any of the four hooks creates a session/peer or writes a
  message, it calls a new `isAdmitted(hookInput)` helper in `config.ts`.
  That helper spawns the configured command, writes the hook's raw
  HookInput JSON to its stdin, and waits (5s timeout) for it to exit.
  Exit 0 admits; any non-zero exit, or a failure to spawn the command at
  all, **rejects (fail-closed)**. A misconfigured or crashing admission
  policy should never silently degrade to "capture everything."

`isAdmitted()` is called at the top of all four hooks -- session-start.ts,
user-prompt.ts, post-tool-use.ts, and stop.ts -- immediately after
hookInput is parsed and before any Honcho API call. A gate in only one
hook leaks: each of the other three independently re-derives the session
and writes to it regardless of what session-start decided.

This is a generic extension point with zero knowledge of any specific
downstream policy -- the command is just a path, invoked the same way
regardless of what it checks (session identity, a peer allowlist, a rate
limit, anything). It's the same shape as `admissionCommand`-style hooks in
other tools (e.g. gitea's webhook allowlist pattern, kubectl admission
webhooks): the tool defines *where* the check runs and *what a pass/fail
looks like*; it never carries the policy itself.

## One note on an existing type gap this patch does NOT fix

`post-tool-use.ts`'s local `HookInput` interface does not declare
`session_id`, even though Claude Code's real PostToolUse event payload
carries it. `JSON.parse` doesn't strip undeclared fields, so
`isAdmitted()` still sees `session_id` at runtime -- this patch works
correctly as written. But the type is misleading on its own and could bite
someone reading only the interface. Worth a separate, unrelated cleanup PR
to add `session_id?: string;` to that interface for accuracy; not touched
here to keep this patch minimal and single-purpose.

## Testing

Verified against a companion admission script (not part of this patch --
that's application-specific policy, lives in the consuming project) that
reads HookInput JSON on stdin, checks session_id against a recorded
allowlist, and exits 0/1 accordingly. Confirmed: with `admissionCommand`
unset, all four hooks behave identically to main (no regression). With it
set, a non-admitted session_id causes all four hooks to exit 0 without any
Honcho API call -- verified against a real 12-real-session sweep run
through the actual hook path (`bun run hooks/session-start.ts`), with the
Honcho client's own activity log showing **zero log lines / zero API
calls** for every rejected session_id, and normal session-creation +
`addMessages` calls preserved for the one admitted (matching) session_id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional admission policy command to control whether activity is captured.
  * Supports configuration at both the global and host-specific levels.
* **Bug Fixes**
  * Events and session data are now blocked when the admission policy rejects a request.
  * Policy failures and non-success responses safely prevent data capture.
  * Admission checks consistently apply across session starts, prompts, tool usage, and stops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->